### PR TITLE
Add shared header logo and fix legal navigation links

### DIFF
--- a/docs/assets/img/dachrinnecheck-logo.svg
+++ b/docs/assets/img/dachrinnecheck-logo.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 120" role="img" aria-labelledby="title desc">
+  <title id="title">DachrinneCheck</title>
+  <desc id="desc">Logo von DachrinneCheck mit stilisiertem Dach und Dachrinne</desc>
+  <defs>
+    <linearGradient id="roofGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0096C7" />
+      <stop offset="100%" stop-color="#0077B6" />
+    </linearGradient>
+    <linearGradient id="gutterGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#023E8A" />
+      <stop offset="100%" stop-color="#03045E" />
+    </linearGradient>
+  </defs>
+  <g transform="translate(10 20)">
+    <path d="M0 48 L60 4 L120 48" fill="none" stroke="url(#roofGradient)" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M18 56 L18 88 L102 88 L102 56" fill="none" stroke="url(#gutterGradient)" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M18 74 C32 70 40 70 56 76 C72 82 80 82 102 78" fill="none" stroke="#64DFDF" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  </g>
+  <text x="150" y="66" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700" font-size="44" letter-spacing="0.5">
+    <tspan fill="#0F172A">Dachrinne</tspan>
+    <tspan fill="#0077B6" dx="10">Check</tspan>
+  </text>
+  <text x="150" y="95" font-family="'Poppins', 'Segoe UI', sans-serif" font-size="16" fill="#475569" letter-spacing="1">
+    <tspan>Professionelle Dachrinnenreinigung in NRW</tspan>
+  </text>
+</svg>

--- a/docs/datenschutz.html
+++ b/docs/datenschutz.html
@@ -42,15 +42,16 @@
 <body class="bg-background-light text-slate-900">
   <header class="bg-white/80 backdrop-blur shadow-sm border-b border-slate-200">
     <div class="max-w-5xl mx-auto px-4 py-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-      <div>
-        <a href="/Homepage.html" class="text-2xl font-semibold text-primary flex items-center space-x-2">
-          <span>DachrinneCheck</span>
+      <div class="flex flex-col items-start gap-2">
+        <a href="index.html" class="inline-flex items-center">
+          <img src="assets/img/dachrinnecheck-logo.svg" alt="DachrinneCheck Logo" class="h-12 md:h-14 w-auto"/>
+          <span class="sr-only">Zur Startseite</span>
         </a>
         <p class="text-sm text-text-light">Professionelle Dachrinnenreinigung in NRW</p>
       </div>
       <div class="flex items-center gap-4 text-sm text-text-light">
-        <a class="hover:text-primary transition" href="/Homepage.html#contact">Kontakt</a>
-        <a class="hover:text-primary transition" href="/Impressum.html">Impressum</a>
+        <a class="hover:text-primary transition" href="index.html#contact">Kontakt</a>
+        <a class="hover:text-primary transition" href="impressum.html">Impressum</a>
       </div>
     </div>
   </header>
@@ -157,8 +158,8 @@
   <footer class="bg-card-dark border-t border-gray-800 py-10 md:py-12">
     <div class="max-w-4xl mx-auto px-4 text-center text-text-dark text-sm space-y-4">
       <div class="flex flex-col md:flex-row justify-center items-center space-y-3 md:space-y-0 md:space-x-8">
-        <a class="hover:text-primary transition" href="/Impressum.html">Impressum</a>
-        <a class="hover:text-primary transition" href="/Homepage.html#contact">Kontakt</a>
+        <a class="hover:text-primary transition" href="impressum.html">Impressum</a>
+        <a class="hover:text-primary transition" href="index.html#contact">Kontakt</a>
       </div>
       <p class="text-xs">© 2024 DachrinneCheck. Alle Rechte vorbehalten.</p>
     </div>

--- a/docs/impressum.html
+++ b/docs/impressum.html
@@ -41,15 +41,16 @@
 <body class="bg-background-light text-slate-900">
   <header class="bg-white/80 backdrop-blur shadow-sm border-b border-slate-200">
     <div class="max-w-5xl mx-auto px-4 py-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-      <div>
-        <a href="/Homepage.html" class="text-2xl font-semibold text-primary flex items-center space-x-2">
-          <span>DachrinneCheck</span>
+      <div class="flex flex-col items-start gap-2">
+        <a href="index.html" class="inline-flex items-center">
+          <img src="assets/img/dachrinnecheck-logo.svg" alt="DachrinneCheck Logo" class="h-12 md:h-14 w-auto"/>
+          <span class="sr-only">Zur Startseite</span>
         </a>
         <p class="text-sm text-text-light">Professionelle Dachrinnenreinigung in NRW</p>
       </div>
       <div class="flex items-center gap-4 text-sm text-text-light">
-        <a class="hover:text-primary transition" href="/Homepage.html#contact">Kontakt</a>
-        <a class="hover:text-primary transition" href="/Datenschutz.html">Datenschutz</a>
+        <a class="hover:text-primary transition" href="index.html#contact">Kontakt</a>
+        <a class="hover:text-primary transition" href="datenschutz.html">Datenschutz</a>
       </div>
     </div>
   </header>
@@ -124,8 +125,8 @@
   <footer class="bg-card-dark border-t border-gray-800 py-10 md:py-12">
     <div class="max-w-4xl mx-auto px-4 text-center text-text-dark text-sm space-y-4">
       <div class="flex flex-col md:flex-row justify-center items-center space-y-3 md:space-y-0 md:space-x-8">
-        <a class="hover:text-primary transition" href="/Datenschutz.html">Datenschutz</a>
-        <a class="hover:text-primary transition" href="/Homepage.html#contact">Kontakt</a>
+        <a class="hover:text-primary transition" href="datenschutz.html">Datenschutz</a>
+        <a class="hover:text-primary transition" href="index.html#contact">Kontakt</a>
       </div>
       <p class="text-xs">© 2024 DachrinneCheck. Alle Rechte vorbehalten.</p>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -100,9 +100,9 @@
 <div class="relative w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }">
 <header @scroll.window="scrolled = window.scrollY &gt; 10" class="sticky top-0 z-30 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg shadow-md transition-all duration-300" x-data="{ scrolled: false }">
 <div class="container mx-auto flex justify-between items-center px-4 py-3">
-<a class="flex items-center space-x-2" href="#">
-<img alt="DachrinneCheck Logo" class="h-8 md:h-10 w-auto" src="https://static.wixstatic.com/media/6d33a0_2223a215c84a4ac48ca665382936b8d5~mv2.png"/>
-<span class="text-lg md:text-xl font-bold text-gray-900 dark:text-white">DachrinneCheck</span>
+<a class="inline-flex items-center" href="index.html">
+<img alt="DachrinneCheck Logo" class="h-12 md:h-14 w-auto" src="assets/img/dachrinnecheck-logo.svg"/>
+<span class="sr-only">Zur Startseite</span>
 </a>
 <div class="hidden md:flex items-center space-x-6">
 <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors" href="#services">Services</a>

--- a/docs/kostenrechner.html
+++ b/docs/kostenrechner.html
@@ -250,13 +250,13 @@
   <div class="relative w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }">
     <header @scroll.window="scrolled = window.scrollY &gt; 10" class="sticky top-0 z-30 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg shadow-md transition-all duration-300" x-data="{ scrolled: false }">
       <div class="container mx-auto flex justify-between items-center px-4 py-3">
-        <a class="flex items-center space-x-2" href="Homepage.html">
-          <img alt="DachrinneCheck Logo" class="h-8 md:h-10 w-auto" src="https://static.wixstatic.com/media/6d33a0_2223a215c84a4ac48ca665382936b8d5~mv2.png"/>
-          <span class="text-lg md:text-xl font-bold text-gray-900 dark:text-white">DachrinneCheck</span>
+        <a class="inline-flex items-center" href="index.html">
+          <img alt="DachrinneCheck Logo" class="h-12 md:h-14 w-auto" src="assets/img/dachrinnecheck-logo.svg"/>
+          <span class="sr-only">Zur Startseite</span>
         </a>
         <div class="hidden md:flex items-center space-x-6">
-          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors" href="Homepage.html#services">Services</a>
-          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors" href="Homepage.html#about">Über uns</a>
+          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors" href="index.html#services">Services</a>
+          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors" href="index.html#about">Über uns</a>
           <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors" href="#kontakt">Kontakt</a>
           <a class="bg-primary text-white font-semibold py-2 px-5 rounded-full text-sm hover:bg-primary-dark transition-all duration-300 shadow transform hover:scale-105" href="#kontakt">
             Angebot anfordern
@@ -270,8 +270,8 @@
       </div>
       <div :class="{'max-h-96': mobileMenuOpen, 'max-h-0': !mobileMenuOpen}" class="md:hidden overflow-hidden transition-all duration-500 ease-in-out">
         <div class="flex flex-col items-center space-y-4 py-4 border-t border-gray-200 dark:border-gray-700">
-          <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2" href="Homepage.html#services">Services</a>
-          <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2" href="Homepage.html#about">Über uns</a>
+          <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2" href="index.html#services">Services</a>
+          <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2" href="index.html#about">Über uns</a>
           <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2" href="#kontakt">Kontakt</a>
           <a @click="mobileMenuOpen = false" class="bg-primary text-white font-semibold py-3 px-8 rounded-full text-base hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105 mt-4" href="#kontakt">
             Angebot anfordern
@@ -395,7 +395,7 @@
                   <label for="cbConsent" class="note">
                     Ich willige ein, dass meine Angaben zur Kontaktaufnahme, Angebotserstellung und Terminabstimmung verarbeitet und gespeichert werden.
                     Die Einwilligung kann ich jederzeit mit Wirkung für die Zukunft widerrufen. Hinweise in der
-                    <a href="/Datenschutz.html" target="_blank" rel="noopener">Datenschutzerklärung</a>.
+                    <a href="datenschutz.html" target="_blank" rel="noopener">Datenschutzerklärung</a>.
                   </label>
                 </div>
 
@@ -429,7 +429,7 @@
     <footer class="bg-card-dark border-t border-gray-800 py-10 md:py-12">
       <div class="container mx-auto px-4 text-center text-text-dark">
         <div class="flex flex-col md:flex-row justify-center items-center space-y-4 md:space-y-0 md:space-x-8 mb-8">
-          <a class="hover:text-primary transition-colors text-sm" href="/Datenschutz.html">Datenschutz</a>
+          <a class="hover:text-primary transition-colors text-sm" href="datenschutz.html">Datenschutz</a>
           <a class="hover:text-primary transition-colors text-sm" href="#">AGB</a>
           <a class="hover:text-primary transition-colors text-sm" href="#kontakt">Kontakt</a>
         </div>


### PR DESCRIPTION
## Summary
- add a reusable DachrinneCheck logo asset and display it in the header of every static page
- ensure the header navigation uses the new logo link back to the homepage instead of plain text labels
- correct the Impressum and Datenschutzerklärung navigation/footer links to point to the local pages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cd524422248329a030c61a01543c74