### PR TITLE
Restore dynamic hero background effect

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -42,6 +42,10 @@
 <link href="assets/css/responsive-nav.css" rel="stylesheet"/>
 <script defer src="assets/js/responsive-nav.js"></script>
 <style>
+    :root {
+      --hero-parallax-offset: 0px;
+    }
+
     body {
       position: relative;
       min-height: max(884px, 100dvh);
@@ -50,14 +54,37 @@
     .text-shadow {
       text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.3);
     }
+    .hero-background-layer {
+      position: fixed;
+      inset: 0;
+      z-index: -10;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      pointer-events: none;
+    }
+    .hero-background-layer::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(to bottom, rgba(15, 23, 42, 0.25) 0%, rgba(15, 23, 42, 0.5) 45%, rgba(15, 23, 42, 0.75) 100%);
+      mix-blend-mode: multiply;
+      pointer-events: none;
+    }
+    .hero-background-layer img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: center;
+      transform: translateY(calc(var(--hero-parallax-offset, 0px) * -0.2)) scale(1.05);
+      transition: transform 0.2s ease-out;
+      will-change: transform;
+    }
     .hero-section {
       position: relative;
       min-height: 24rem;
       height: min(70vh, 720px);
       max-height: 720px;
-    }
-    .hero-background {
-      position: fixed;
     }
     [x-cloak] {
       display: none !important;
@@ -87,7 +114,10 @@
 </style>
   </head>
 <body class="bg-background-light dark:bg-background-dark font-display">
-<div class="relative z-10 w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }">
+<div aria-hidden="true" class="hero-background-layer">
+    <img alt="Fachkraft reinigt eine Dachrinne an einem Wohnhaus in Nordrhein-Westfalen" src="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png"/>
+  </div>
+  <div class="relative z-10 w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }">
 <header @scroll.window="scrolled = window.scrollY &gt; 10" class="sticky top-0 z-30 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg shadow-md transition-all duration-300 responsive-header" data-responsive-header x-data="{ scrolled: false }">
 <div class="container mx-auto flex justify-between items-center px-4 py-4 md:py-5" data-nav-inner>
 <a class="inline-flex items-center" data-nav-logo href="index.html">
@@ -137,7 +167,6 @@
 </div>
 </header>
 <section class="relative flex flex-col items-start justify-center text-white overflow-hidden hero-section">
-<img alt="Fachkraft reinigt eine Dachrinne an einem Wohnhaus in Nordrhein-Westfalen" class="absolute inset-0 w-full h-full object-cover object-center -z-10 hero-background pointer-events-none" src="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png"/>
 <div class="absolute inset-0 bg-slate-900/60"></div>
 <div class="relative z-10 p-6 md:p-12 max-w-4xl pt-20">
 <h1 class="text-4xl md:text-7xl font-black leading-tight tracking-tight mb-4 md:mb-6 text-shadow">Professionelle Dachrinnenreinigung in NRW</h1>
@@ -490,6 +519,54 @@ Original lesen
 </div>
 
 <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const rootElement = document.documentElement;
+    const heroBackground = document.querySelector('.hero-background-layer');
+    const heroSection = document.querySelector('.hero-section');
+
+    if (!rootElement || !heroBackground || !heroSection) {
+      return;
+    }
+
+    const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    let heroTop = heroSection.offsetTop;
+    let heroHeight = heroSection.offsetHeight;
+
+    const setOffset = value => {
+      rootElement.style.setProperty('--hero-parallax-offset', `${value}px`);
+    };
+
+    const updateOffset = () => {
+      if (prefersReducedMotion.matches) {
+        setOffset(0);
+        return;
+      }
+
+      const scrollPosition = window.scrollY || window.pageYOffset || 0;
+      const relativeScroll = clamp(scrollPosition - heroTop, 0, heroHeight);
+      setOffset(relativeScroll);
+    };
+
+    const updateMetrics = () => {
+      heroTop = heroSection.offsetTop;
+      heroHeight = heroSection.offsetHeight;
+      updateOffset();
+    };
+
+    updateMetrics();
+
+    window.addEventListener('scroll', updateOffset, { passive: true });
+    window.addEventListener('resize', updateMetrics);
+
+    if (typeof prefersReducedMotion.addEventListener === 'function') {
+      prefersReducedMotion.addEventListener('change', updateOffset);
+    } else if (typeof prefersReducedMotion.addListener === 'function') {
+      prefersReducedMotion.addListener(updateOffset);
+    }
+  });
+
   const RAW_REVIEWS = [
     {
       "id": "0024a6a5-efce-4ed2-8b0b-c3240ab043ea",


### PR DESCRIPTION
## Summary
- add a fixed hero background layer that sits behind the content so later sections scroll over the image again
- animate the hero background with a lightweight parallax offset that respects prefers-reduced-motion

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68cd769378fc8329b47b0c0ebba2e97a