### PR TITLE
Keep hero background static during scroll

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -50,14 +50,34 @@
     .text-shadow {
       text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.3);
     }
+    .hero-background-layer {
+      position: fixed;
+      inset: 0;
+      z-index: -10;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      pointer-events: none;
+    }
+    .hero-background-layer::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(to bottom, rgba(15, 23, 42, 0.25) 0%, rgba(15, 23, 42, 0.5) 45%, rgba(15, 23, 42, 0.75) 100%);
+      mix-blend-mode: multiply;
+      pointer-events: none;
+    }
+    .hero-background-layer img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: center;
+    }
     .hero-section {
       position: relative;
       min-height: 24rem;
       height: min(70vh, 720px);
       max-height: 720px;
-    }
-    .hero-background {
-      position: fixed;
     }
     [x-cloak] {
       display: none !important;
@@ -87,7 +107,10 @@
 </style>
   </head>
 <body class="bg-background-light dark:bg-background-dark font-display">
-<div class="relative z-10 w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }">
+<div aria-hidden="true" class="hero-background-layer">
+    <img alt="Fachkraft reinigt eine Dachrinne an einem Wohnhaus in Nordrhein-Westfalen" src="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png"/>
+  </div>
+  <div class="relative z-10 w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }">
 <header @scroll.window="scrolled = window.scrollY &gt; 10" class="sticky top-0 z-30 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg shadow-md transition-all duration-300 responsive-header" data-responsive-header x-data="{ scrolled: false }">
 <div class="container mx-auto flex justify-between items-center px-4 py-4 md:py-5" data-nav-inner>
 <a class="inline-flex items-center" data-nav-logo href="index.html">
@@ -137,7 +160,6 @@
 </div>
 </header>
 <section class="relative flex flex-col items-start justify-center text-white overflow-hidden hero-section">
-<img alt="Fachkraft reinigt eine Dachrinne an einem Wohnhaus in Nordrhein-Westfalen" class="absolute inset-0 w-full h-full object-cover object-center -z-10 hero-background pointer-events-none" src="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png"/>
 <div class="absolute inset-0 bg-slate-900/60"></div>
 <div class="relative z-10 p-6 md:p-12 max-w-4xl pt-20">
 <h1 class="text-4xl md:text-7xl font-black leading-tight tracking-tight mb-4 md:mb-6 text-shadow">Professionelle Dachrinnenreinigung in NRW</h1>


### PR DESCRIPTION
## Summary
- remove the parallax CSS variable and transform from the hero background
- drop the scroll listener script so the hero image stays fixed while other sections scroll

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68cd769378fc8329b47b0c0ebba2e97a