### PR TITLE
Fix hero background layout for Wix

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -76,12 +76,18 @@
     .text-shadow {
       text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.3);
     }
+    .hero-section {
+      position: relative;
+      min-height: 24rem;
+      height: min(70vh, 720px);
+      max-height: 720px;
+      overflow: hidden;
+      isolation: isolate;
+    }
     .hero-background-layer {
-      position: fixed;
+      position: absolute;
       inset: 0;
-      z-index: -10;
-      width: 100%;
-      height: 100%;
+      z-index: 0;
       overflow: hidden;
       pointer-events: none;
     }
@@ -98,15 +104,16 @@
       height: 100%;
       object-fit: cover;
       object-position: center;
-      transform: translateY(calc(var(--hero-parallax-offset, 0px) * -0.2)) scale(1.05);
+      transform: translate3d(0, calc(var(--hero-parallax-offset, 0px) * -0.2), 0) scale(1.12);
+      transform-origin: center;
       transition: transform 0.2s ease-out;
       will-change: transform;
     }
-    .hero-section {
-      position: relative;
-      min-height: 24rem;
-      height: min(70vh, 720px);
-      max-height: 720px;
+    .hero-overlay {
+      position: absolute;
+      inset: 0;
+      z-index: 1;
+      pointer-events: none;
     }
     [x-cloak] {
       display: none !important;
@@ -167,9 +174,6 @@
 </script>
   </head>
 <body class="bg-background-light dark:bg-background-dark font-display">
-<div aria-hidden="true" class="hero-background-layer">
-    <img alt="Fachkraft reinigt eine Dachrinne an einem Wohnhaus in Willich, NRW" decoding="async" fetchpriority="high" loading="lazy" src="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png"/>
-  </div>
   <div class="relative z-10 w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }">
 <header @scroll.window="scrolled = window.scrollY &gt; 10" class="sticky top-0 z-30 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg shadow-md transition-all duration-300 responsive-header" data-responsive-header x-data="{ scrolled: false }">
 <div class="container mx-auto flex justify-between items-center px-4 py-4 md:py-5" data-nav-inner>
@@ -220,8 +224,11 @@
 </div>
 </header>
 <section class="relative flex flex-col items-start justify-center text-white overflow-hidden hero-section">
-<div class="absolute inset-0 bg-slate-900/60"></div>
-<div class="relative z-10 p-6 md:p-12 max-w-4xl pt-20">
+  <div aria-hidden="true" class="hero-background-layer">
+    <img alt="Fachkraft reinigt eine Dachrinne an einem Wohnhaus in Willich, NRW" decoding="async" fetchpriority="high" loading="lazy" src="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png"/>
+  </div>
+  <div class="hero-overlay absolute inset-0 bg-slate-900/60"></div>
+  <div class="relative z-10 p-6 md:p-12 max-w-4xl pt-20">
 <h1 class="text-4xl md:text-7xl font-black leading-tight tracking-tight mb-4 md:mb-6 text-shadow">Professionelle Dachrinnenreinigung in NRW</h1>
 <p class="text-lg md:text-2xl mb-8 md:mb-10 text-shadow font-light">Schützen Sie Ihr Eigentum vor Wasserschäden – wir reinigen Dachrinnen in Willich, Krefeld, Düsseldorf und ganz NRW. Fordern Sie noch heute ein kostenloses Angebot an.</p>
 <div class="flex flex-col sm:flex-row gap-4">


### PR DESCRIPTION
## Summary
- move the hero background image inside the hero section so it no longer stretches across the entire Wix page
- adjust the hero background styling and overlay layering to preserve the parallax effect while keeping the image scoped to the hero area

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_b_68cd955644e48329ad2448ff9f7f0185