### PR TITLE
Remove hero background image and adjust hero styling

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,6 @@
 <link crossorigin="" href="https://static.wixstatic.com" rel="preconnect"/>
 <link crossorigin="" href="https://video.wixstatic.com" rel="preconnect"/>
 <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;900&amp;display=swap" rel="stylesheet"/>
-<link as="image" fetchpriority="high" href="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png" rel="preload"/>
 <link href="assets/img/dachrinnecheck-logo.svg" rel="icon" type="image/svg+xml"/>
 <meta content="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png" property="og:image"/>
 <meta content="Sauber gereinigte Dachrinne an einem Wohnhaus in Willich" property="og:image:alt"/>
@@ -73,9 +72,6 @@
       min-height: max(884px, 100dvh);
     }
 
-    .text-shadow {
-      text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.3);
-    }
     .hero-section {
       position: relative;
       min-height: 24rem;
@@ -83,37 +79,6 @@
       max-height: 720px;
       overflow: hidden;
       isolation: isolate;
-    }
-    .hero-background-layer {
-      position: absolute;
-      inset: 0;
-      z-index: 0;
-      overflow: hidden;
-      pointer-events: none;
-    }
-    .hero-background-layer::after {
-      content: "";
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(to bottom, rgba(15, 23, 42, 0.25) 0%, rgba(15, 23, 42, 0.5) 45%, rgba(15, 23, 42, 0.75) 100%);
-      mix-blend-mode: multiply;
-      pointer-events: none;
-    }
-    .hero-background-layer img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      object-position: center;
-      transform: translate3d(0, calc(var(--hero-parallax-offset, 0px) * -0.2), 0) scale(1.12);
-      transform-origin: center;
-      transition: transform 0.2s ease-out;
-      will-change: transform;
-    }
-    .hero-overlay {
-      position: absolute;
-      inset: 0;
-      z-index: 1;
-      pointer-events: none;
     }
     [x-cloak] {
       display: none !important;
@@ -223,14 +188,10 @@
 </nav>
 </div>
 </header>
-<section class="relative flex flex-col items-start justify-center text-white overflow-hidden hero-section">
-  <div aria-hidden="true" class="hero-background-layer">
-    <img alt="Fachkraft reinigt eine Dachrinne an einem Wohnhaus in Willich, NRW" decoding="async" fetchpriority="high" loading="lazy" src="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png"/>
-  </div>
-  <div class="hero-overlay absolute inset-0 bg-slate-900/60"></div>
+<section class="relative flex flex-col items-start justify-center overflow-hidden hero-section text-gray-900 dark:text-white">
   <div class="relative z-10 p-6 md:p-12 max-w-4xl pt-20">
-<h1 class="text-4xl md:text-7xl font-black leading-tight tracking-tight mb-4 md:mb-6 text-shadow">Professionelle Dachrinnenreinigung in NRW</h1>
-<p class="text-lg md:text-2xl mb-8 md:mb-10 text-shadow font-light">Schützen Sie Ihr Eigentum vor Wasserschäden – wir reinigen Dachrinnen in Willich, Krefeld, Düsseldorf und ganz NRW. Fordern Sie noch heute ein kostenloses Angebot an.</p>
+<h1 class="text-4xl md:text-7xl font-black leading-tight tracking-tight mb-4 md:mb-6">Professionelle Dachrinnenreinigung in NRW</h1>
+<p class="text-lg md:text-2xl mb-8 md:mb-10 font-light text-text-light dark:text-text-dark">Schützen Sie Ihr Eigentum vor Wasserschäden – wir reinigen Dachrinnen in Willich, Krefeld, Düsseldorf und ganz NRW. Fordern Sie noch heute ein kostenloses Angebot an.</p>
 <div class="flex flex-col sm:flex-row gap-4">
           <a class="bg-primary text-white font-bold py-3 px-6 md:py-4 md:px-8 rounded-full text-base md:text-lg hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105 text-center" href="kostenrechner.html">
             Zum Kostenrechner


### PR DESCRIPTION
## Summary
- remove the hero section background image and overlay so the hero area stays transparent
- update hero text classes to remain legible on light and dark themes after removing the image
- clean up unused hero-specific CSS rules and the old image preload tag

## Testing
- not run (static changes)


------
https://chatgpt.com/codex/tasks/task_b_68cd984f8cec8329926f72f7d4c14ccf