### PR TITLE
Adjust hero height on mobile and reduce calculator padding

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -129,12 +129,15 @@
       .hero-heading {
         font-size: clamp(2rem, 6vw + 1rem, 3rem);
       }
+      :root {
+        --hero-base-offset: -32px;
+      }
     }
     @media (max-width: 768px) {
       .hero-section {
-        height: auto;
-        min-height: 100svh;
-        max-height: none;
+        min-height: 20rem;
+        height: min(85vh, 520px);
+        max-height: 520px;
       }
     }
     @keyframes reveal {

--- a/docs/kostenrechner.html
+++ b/docs/kostenrechner.html
@@ -116,6 +116,11 @@
       flex-direction:column;
       gap:24px;
     }
+    @media (max-width: 768px){
+      .wrap{
+        padding:0 0.75rem 2.5rem;
+      }
+    }
 
     .hero{
       position:relative;


### PR DESCRIPTION
## Summary
- limit the hero section height on small screens so the image stays within a compact viewport
- tweak the mobile parallax offset to keep the hero background framing consistent
- reduce the horizontal padding of the cost calculator wrapper on tablets and phones for a tighter layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cdaaab76008329a2c9ec764f159591