### PR TITLE
Fix mobile hero layout and sticky total visibility

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -74,9 +74,9 @@
 
     .hero-section {
       position: relative;
-      min-height: 24rem;
-      height: min(70vh, 900px);
-      max-height: 900px;
+      min-height: clamp(24rem, 70vh, 900px);
+      height: auto;
+      max-height: none;
       overflow: hidden;
       isolation: isolate;
       background-color: #0f172a;
@@ -134,9 +134,13 @@
     }
     @media (max-width: 768px) {
       .hero-section {
-        min-height: 20rem;
-        height: min(85vh, 520px);
-        max-height: 520px;
+        min-height: clamp(28rem, 92vh, 640px);
+      }
+    }
+    @media (max-width: 640px) {
+      .hero-content {
+        padding-top: clamp(6.5rem, 18vw + 2rem, 9rem);
+        padding-bottom: clamp(3rem, 12vw, 5rem);
       }
     }
     @keyframes reveal {
@@ -238,7 +242,7 @@
 </div>
 </header>
 <section class="relative flex flex-col items-center md:items-start justify-center overflow-hidden hero-section text-white">
-  <div class="relative z-10 w-full max-w-4xl px-6 pt-32 pb-16 text-center text-white md:px-12 md:py-24 md:text-left">
+  <div class="relative z-10 w-full max-w-4xl px-6 pt-32 pb-16 text-center text-white md:px-12 md:py-24 md:text-left hero-content">
 <h1 class="hero-heading font-black leading-tight tracking-tight text-shadow mb-4 md:mb-6 max-w-3xl mx-auto md:mx-0">Dachrinnenreinigung in NRW – sauber, sicher und termintreu</h1>
 <p class="text-lg md:text-2xl mb-8 md:mb-10 font-light text-shadow text-slate-100 max-w-2xl mx-auto md:mx-0">Wir halten Dachrinnen in Willich, Krefeld, Düsseldorf und ganz NRW frei von Schmutz – zuverlässig, sicher und mit moderner Ausrüstung. Nutzen Sie unseren Kostenrechner und erhalten Sie Ihr Angebot innerhalb von 24 Stunden.</p>
 <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-center md:justify-start md:items-center">

--- a/docs/kostenrechner.html
+++ b/docs/kostenrechner.html
@@ -269,7 +269,8 @@
     .mobile-total{display:none}
 
     @media (max-width:900px){
-      .mobile-total{position:fixed;left:0;right:0;bottom:0;z-index:2000;background:rgba(255,255,255,0.95);border-top:1px solid rgba(15,23,42,0.08);padding:12px 16px calc(14px + env(safe-area-inset-bottom,0px));display:flex;align-items:center;justify-content:space-between;gap:14px;box-shadow:0 -12px 28px rgba(15,23,42,0.15);backdrop-filter:blur(8px)}
+      .mobile-total{position:fixed;left:0;right:0;bottom:0;z-index:2000;background:rgba(255,255,255,0.95);border-top:1px solid rgba(15,23,42,0.08);padding:12px 16px calc(14px + env(safe-area-inset-bottom,0px));display:flex;align-items:center;justify-content:space-between;gap:14px;box-shadow:0 -12px 28px rgba(15,23,42,0.15);backdrop-filter:blur(8px);opacity:0;visibility:hidden;pointer-events:none;transform:translateY(100%);transition:transform .3s ease,opacity .3s ease,visibility .3s ease}
+      .mobile-total.is-visible{opacity:1;visibility:visible;pointer-events:auto;transform:translateY(0)}
       .dark .mobile-total{background:rgba(26,32,44,0.94);border-top:1px solid rgba(226,232,240,0.12);box-shadow:0 -14px 32px rgba(0,0,0,0.45)}
       .mobile-total .price{font-size:1.35rem}
       /* padding-bottom anpassen, um den Fixed Footer zu berücksichtigen */
@@ -870,6 +871,7 @@
     // Blur focused fields and scroll to top to avoid mobile zoom sticking around
     document.querySelectorAll('input,textarea,select').forEach(el=>el.blur());
     window.scrollTo({ top: 0, behavior: 'smooth' });
+    updateMobileTotalVisibility();
     updateSubmitState();
 
     // --- Auto-Resize: Höhe an Wix melden (verbesserter Mechanismus) ---
@@ -898,6 +900,39 @@
       setTimeout(postHeight, 1000);
       setTimeout(postHeight, 3000); // Eine letzte Verzögerung, falls alles andere fehlschlägt
     })();
+  }
+
+  const mobileTotalEl = document.getElementById('mobileTotal');
+  const heroSection = document.getElementById('preisrechner');
+  const mobileMq = typeof window.matchMedia === 'function'
+    ? window.matchMedia('(max-width: 900px)')
+    : { matches: window.innerWidth <= 900 };
+
+  function updateMobileTotalVisibility(){
+    if(!mobileTotalEl) return;
+    const isMobile = mobileMq.matches;
+    if(!isMobile){
+      mobileTotalEl.classList.remove('is-visible');
+      return;
+    }
+    if(!heroSection){
+      mobileTotalEl.classList.add('is-visible');
+      return;
+    }
+    const rect = heroSection.getBoundingClientRect();
+    const shouldShow = rect.bottom <= window.innerHeight * 0.85;
+    mobileTotalEl.classList.toggle('is-visible', shouldShow);
+  }
+
+  if(mobileTotalEl){
+    updateMobileTotalVisibility();
+    window.addEventListener('scroll', updateMobileTotalVisibility, { passive:true });
+    window.addEventListener('resize', updateMobileTotalVisibility);
+    if(typeof mobileMq.addEventListener === 'function'){
+      mobileMq.addEventListener('change', updateMobileTotalVisibility);
+    } else if(typeof mobileMq.addListener === 'function'){
+      mobileMq.addListener(updateMobileTotalVisibility);
+    }
   }
 
   function updateSubmitState(){


### PR DESCRIPTION
## Summary
- allow the homepage hero section to grow with its content on small screens so both CTA buttons stay visible
- tweak mobile hero padding for better spacing when the viewport shrinks
- hide the Kostenrechner sticky total on load and reveal it only after scrolling past the intro card to avoid covering content

## Testing
- python3 -m http.server 8000 -d docs (manual mobile viewport verification)


------
https://chatgpt.com/codex/tasks/task_b_68cdac335a648329a4e2b503908825ad