### PR TITLE
Fix responsive navigation toggle

### DIFF
--- a/docs/assets/css/responsive-nav.css
+++ b/docs/assets/css/responsive-nav.css
@@ -12,6 +12,10 @@
   align-items: center;
 }
 
+.responsive-header .nav-toggle [data-nav-icon] {
+  transition: transform 0.2s ease;
+}
+
 @media (min-width: 768px) {
   .responsive-header .nav-toggle {
     display: none;
@@ -24,6 +28,14 @@
 
 .responsive-header.is-collapsed .nav-inline {
   display: none !important;
+}
+
+.responsive-header .nav-dialog-backdrop {
+  max-height: 0;
+}
+
+.responsive-header .nav-dialog-backdrop.is-visible {
+  max-height: 100vh !important;
 }
 
 .responsive-header.menu-open {
@@ -69,6 +81,10 @@
 .nav-dialog-backdrop.is-visible .nav-dialog {
   transform: translateY(0);
   opacity: 1;
+}
+
+.responsive-header.menu-open .nav-toggle [data-nav-icon] {
+  transform: rotate(180deg);
 }
 
 .dark .nav-dialog {

--- a/docs/datenschutz.html
+++ b/docs/datenschutz.html
@@ -62,7 +62,7 @@
   </style>
 </head>
 <body class="bg-background-light dark:bg-background-dark font-display text-slate-900">
-  <div class="relative w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }">
+  <div class="relative w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }" x-on:responsive-nav-toggle.window="mobileMenuOpen = $event.detail.open">
     <header @scroll.window="scrolled = window.scrollY &gt; 10" class="sticky top-0 z-30 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg shadow-md transition-all duration-300 responsive-header" data-responsive-header x-data="{ scrolled: false }">
       <div class="container mx-auto flex justify-between items-center px-4 py-4 md:py-5" data-nav-inner>
         <a class="inline-flex items-center" data-nav-logo href="index.html">
@@ -82,8 +82,8 @@
         </div>
         <div class="md:hidden nav-toggle">
           <button @click="mobileMenuOpen = !mobileMenuOpen" aria-controls="primary-navigation" aria-expanded="false" class="text-gray-900 dark:text-white p-2" data-nav-label-close="Menü schließen" data-nav-label-open="Menü öffnen" data-nav-toggle type="button">
-            <span aria-hidden="true" class="material-symbols-outlined text-3xl">menu</span>
-            <span class="sr-only">Menü</span>
+            <span aria-hidden="true" class="material-symbols-outlined text-3xl" data-nav-icon data-nav-icon-closed="menu" data-nav-icon-open="close">menu</span>
+            <span class="sr-only" data-nav-sr>Menü</span>
           </button>
         </div>
       </div>

--- a/docs/impressum.html
+++ b/docs/impressum.html
@@ -61,7 +61,7 @@
   </style>
 </head>
 <body class="bg-background-light dark:bg-background-dark font-display text-slate-900">
-  <div class="relative w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }">
+  <div class="relative w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }" x-on:responsive-nav-toggle.window="mobileMenuOpen = $event.detail.open">
     <header @scroll.window="scrolled = window.scrollY &gt; 10" class="sticky top-0 z-30 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg shadow-md transition-all duration-300 responsive-header" data-responsive-header x-data="{ scrolled: false }">
       <div class="container mx-auto flex justify-between items-center px-4 py-4 md:py-5" data-nav-inner>
         <a class="inline-flex items-center" data-nav-logo href="index.html">
@@ -81,8 +81,8 @@
         </div>
         <div class="md:hidden nav-toggle">
           <button @click="mobileMenuOpen = !mobileMenuOpen" aria-controls="primary-navigation" aria-expanded="false" class="text-gray-900 dark:text-white p-2" data-nav-label-close="Menü schließen" data-nav-label-open="Menü öffnen" data-nav-toggle type="button">
-            <span aria-hidden="true" class="material-symbols-outlined text-3xl">menu</span>
-            <span class="sr-only">Menü</span>
+            <span aria-hidden="true" class="material-symbols-outlined text-3xl" data-nav-icon data-nav-icon-closed="menu" data-nav-icon-open="close">menu</span>
+            <span class="sr-only" data-nav-sr>Menü</span>
           </button>
         </div>
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -193,7 +193,7 @@
 </script>
   </head>
 <body class="bg-background-light dark:bg-background-dark font-display">
-  <div class="relative z-10 w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }">
+  <div class="relative z-10 w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }" x-on:responsive-nav-toggle.window="mobileMenuOpen = $event.detail.open">
 <header @scroll.window="scrolled = window.scrollY &gt; 10" class="sticky top-0 z-30 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg shadow-md transition-all duration-300 responsive-header" data-responsive-header x-data="{ scrolled: false }">
 <div class="container mx-auto flex justify-between items-center px-4 py-4 md:py-5" data-nav-inner>
 <a class="inline-flex items-center" data-nav-logo href="index.html">
@@ -213,8 +213,8 @@
 </div>
 <div class="md:hidden nav-toggle">
 <button @click="mobileMenuOpen = !mobileMenuOpen" aria-controls="primary-navigation" aria-expanded="false" class="text-gray-900 dark:text-white p-2" data-nav-label-close="Menü schließen" data-nav-label-open="Menü öffnen" data-nav-toggle type="button">
-<span aria-hidden="true" class="material-symbols-outlined text-3xl">menu</span>
-<span class="sr-only">Menü</span>
+<span aria-hidden="true" class="material-symbols-outlined text-3xl" data-nav-icon data-nav-icon-closed="menu" data-nav-icon-open="close">menu</span>
+<span class="sr-only" data-nav-sr>Menü</span>
 </button>
 </div>
 </div>

--- a/docs/kostenrechner.html
+++ b/docs/kostenrechner.html
@@ -313,7 +313,7 @@
   </style>
 </head>
 <body class="bg-background-light dark:bg-background-dark font-display">
-  <div class="relative w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }">
+  <div class="relative w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }" x-on:responsive-nav-toggle.window="mobileMenuOpen = $event.detail.open">
     <header @scroll.window="scrolled = window.scrollY &gt; 10" class="sticky top-0 z-30 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg shadow-md transition-all duration-300 responsive-header" data-responsive-header x-data="{ scrolled: false }">
       <div class="container mx-auto flex justify-between items-center px-4 py-4 md:py-5" data-nav-inner>
         <a class="inline-flex items-center" data-nav-logo href="index.html">
@@ -333,8 +333,8 @@
         </div>
         <div class="md:hidden nav-toggle">
           <button @click="mobileMenuOpen = !mobileMenuOpen" aria-controls="primary-navigation" aria-expanded="false" class="text-gray-900 dark:text-white p-2" data-nav-label-close="Menü schließen" data-nav-label-open="Menü öffnen" data-nav-toggle type="button">
-            <span aria-hidden="true" class="material-symbols-outlined text-3xl">menu</span>
-            <span class="sr-only">Menü</span>
+            <span aria-hidden="true" class="material-symbols-outlined text-3xl" data-nav-icon data-nav-icon-closed="menu" data-nav-icon-open="close">menu</span>
+            <span class="sr-only" data-nav-sr>Menü</span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- connect the mobile navigation markup to the responsive-nav.js toggle events
- update the toggle button icon and accessible labels when the menu opens or closes
- ensure the overlay menu can expand to full height while keeping the inline navigation responsive

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_b_68cdb945853c83299f5282f728a51c9b