### PR TITLE
Use extensionless URLs for site navigation

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -6,7 +6,7 @@
   <base href="https://www.dachrinnecheck.de/" />
   <title>Seite nicht gefunden | DachrinneCheck</title>
   <meta name="description" content="Die gewünschte Seite wurde nicht gefunden. Kehren Sie zur Startseite von DachrinneCheck zurück und entdecken Sie unseren Dachrinnenservice in NRW." />
-  <link rel="canonical" href="https://www.dachrinnecheck.de/404.html" />
+  <link rel="canonical" href="https://www.dachrinnecheck.de/404" />
   <meta name="robots" content="noindex,follow" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -34,7 +34,7 @@
     </div>
     <h1>Seite nicht gefunden</h1>
     <p>Die von Ihnen angeforderte Seite existiert nicht mehr oder die Adresse wurde angepasst. Kehren Sie zur Startseite zurück und entdecken Sie unseren Dachrinnenservice für Willich, Krefeld, Düsseldorf &amp; ganz NRW.</p>
-    <a class="button" href="index.html">Zur Startseite</a>
+    <a class="button" href="/">Zur Startseite</a>
   </main>
 </body>
 </html>

--- a/docs/datenschutz.html
+++ b/docs/datenschutz.html
@@ -6,7 +6,7 @@
   <base href="https://www.dachrinnecheck.de/" />
   <title>Datenschutzerklärung DachrinneCheck NRW | Dachrinnenservice</title>
   <meta name="description" content="Datenschutzerklärung von DachrinneCheck – Transparenz zur Dachrinnenreinigung, Laubschutz und Kontaktformularen in Willich, Krefeld, Düsseldorf &amp; ganz NRW." />
-  <link rel="canonical" href="https://www.dachrinnecheck.de/datenschutz.html" />
+  <link rel="canonical" href="https://www.dachrinnecheck.de/datenschutz" />
   <meta name="robots" content="index,follow" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -14,14 +14,14 @@
   <link href="assets/img/dachrinnecheck-logo.svg" rel="icon" type="image/svg+xml" />
   <meta property="og:title" content="Datenschutzerklärung DachrinneCheck NRW | Dachrinnenservice" />
   <meta property="og:description" content="Datenschutzerklärung von DachrinneCheck – Transparenz zur Dachrinnenreinigung, Laubschutz und Kontaktformularen in Willich, Krefeld, Düsseldorf &amp; ganz NRW." />
-  <meta property="og:url" content="https://www.dachrinnecheck.de/datenschutz.html" />
+  <meta property="og:url" content="https://www.dachrinnecheck.de/datenschutz" />
   <meta property="og:type" content="article" />
   <meta property="og:locale" content="de_DE" />
   <meta property="og:site_name" content="DachrinneCheck" />
   <meta property="og:image" content="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png" />
   <meta property="og:image:alt" content="Sauber gereinigte Dachrinne an einem Einfamilienhaus in Willich" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:url" content="https://www.dachrinnecheck.de/datenschutz.html" />
+  <meta name="twitter:url" content="https://www.dachrinnecheck.de/datenschutz" />
   <meta name="twitter:title" content="Datenschutzerklärung DachrinneCheck NRW | Dachrinnenservice" />
   <meta name="twitter:description" content="Datenschutzerklärung von DachrinneCheck – Transparenz zur Dachrinnenreinigung, Laubschutz und Kontaktformularen in Willich, Krefeld, Düsseldorf &amp; ganz NRW." />
   <meta name="twitter:image" content="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png" />
@@ -129,18 +129,18 @@
   <div class="relative w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }" x-on:responsive-nav-toggle.window="mobileMenuOpen = $event.detail.open">
     <header @scroll.window="scrolled = window.scrollY &gt; 10" class="sticky top-0 z-30 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg shadow-md transition-all duration-300 responsive-header" data-responsive-header x-data="{ scrolled: false }">
       <div class="container mx-auto flex justify-between items-center px-4 py-4 md:py-5" data-nav-inner>
-        <a class="inline-flex items-center" data-nav-logo href="index.html">
+        <a class="inline-flex items-center" data-nav-logo href="/">
           <img alt="DachrinneCheck Logo für Dachrinnenreinigung NRW" class="h-16 md:h-20 w-auto" loading="lazy" src="https://static.wixstatic.com/media/6d33a0_2f72c9b480724f2b83a3784dddd3aa8f~mv2.png"/>
           <span class="sr-only">Zur Startseite</span>
         </a>
         <div class="hidden md:flex items-center gap-6 lg:gap-8 nav-inline" data-nav-inline>
-          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="index.html#services">Services</a>
-          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="index.html#about">Über uns</a>
-          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="index.html#contact">Kontakt</a>
-          <a class="bg-primary text-white font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base hover:bg-primary-dark transition-all duration-300 shadow transform hover:scale-105" href="kostenrechner.html">
+            <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="/#services">Services</a>
+            <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="/#about">Über uns</a>
+            <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="/#contact">Kontakt</a>
+          <a class="bg-primary text-white font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base hover:bg-primary-dark transition-all duration-300 shadow transform hover:scale-105" href="/kostenrechner">
             Zum Kostenrechner
           </a>
-          <a class="bg-white text-primary font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow-sm" href="index.html#contact">
+          <a class="bg-white text-primary font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow-sm" href="/#contact">
             Angebot anfordern
           </a>
         </div>
@@ -159,15 +159,15 @@
           </button>
           <div class="flex flex-col items-center space-y-4 py-4 border-t border-gray-200 dark:border-gray-700 nav-dialog-content">
             <div class="nav-dialog-links w-full flex flex-col items-center space-y-4">
-              <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="index.html#services">Services</a>
-              <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="index.html#about">Über uns</a>
-              <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="index.html#contact">Kontakt</a>
+                <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="/#services">Services</a>
+                <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="/#about">Über uns</a>
+                <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="/#contact">Kontakt</a>
             </div>
             <div class="nav-dialog-actions w-full flex flex-col items-center space-y-3">
-              <a @click="mobileMenuOpen = false" class="bg-primary text-white font-semibold py-3 px-8 rounded-full text-base hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105 mt-2 w-full" data-nav-close href="kostenrechner.html">
+              <a @click="mobileMenuOpen = false" class="bg-primary text-white font-semibold py-3 px-8 rounded-full text-base hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105 mt-2 w-full" data-nav-close href="/kostenrechner">
                 Zum Kostenrechner
               </a>
-              <a @click="mobileMenuOpen = false" class="bg-white text-primary font-semibold py-3 px-8 rounded-full text-base border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow mt-2 w-full" data-nav-close href="index.html#contact">
+                <a @click="mobileMenuOpen = false" class="bg-white text-primary font-semibold py-3 px-8 rounded-full text-base border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow mt-2 w-full" data-nav-close href="/#contact">
                 Angebot anfordern
               </a>
             </div>
@@ -278,10 +278,10 @@
     <footer class="bg-card-dark border-t border-gray-800 py-10 md:py-12">
       <div class="container mx-auto px-4 text-center text-text-dark">
         <div class="flex flex-col md:flex-row justify-center items-center space-y-4 md:space-y-0 md:space-x-8 mb-8">
-          <a class="hover:text-primary transition-colors text-sm" href="./datenschutz.html">Datenschutz</a>
-          <a class="hover:text-primary transition-colors text-sm" href="./impressum.html">Impressum</a>
-          <a class="hover:text-primary transition-colors text-sm" href="kostenrechner.html">Kostenrechner</a>
-          <a class="hover:text-primary transition-colors text-sm" href="index.html#contact">Kontakt</a>
+          <a class="hover:text-primary transition-colors text-sm" href="/datenschutz">Datenschutz</a>
+          <a class="hover:text-primary transition-colors text-sm" href="/impressum">Impressum</a>
+          <a class="hover:text-primary transition-colors text-sm" href="/kostenrechner">Kostenrechner</a>
+          <a class="hover:text-primary transition-colors text-sm" href="/#contact">Kontakt</a>
         </div>
         <p class="text-xs">© 2024 DachrinneCheck. Alle Rechte vorbehalten.</p>
       </div>

--- a/docs/impressum.html
+++ b/docs/impressum.html
@@ -6,7 +6,7 @@
   <base href="https://www.dachrinnecheck.de/" />
   <title>Impressum DachrinneCheck NRW | Dachrinnenservice</title>
   <meta name="description" content="Impressum von DachrinneCheck – Dachrinnenservice für Willich, Krefeld, Düsseldorf und ganz Nordrhein-Westfalen." />
-  <link rel="canonical" href="https://www.dachrinnecheck.de/impressum.html" />
+  <link rel="canonical" href="https://www.dachrinnecheck.de/impressum" />
   <meta name="robots" content="index,follow" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -14,14 +14,14 @@
   <link href="assets/img/dachrinnecheck-logo.svg" rel="icon" type="image/svg+xml" />
   <meta property="og:title" content="Impressum DachrinneCheck NRW | Dachrinnenservice" />
   <meta property="og:description" content="Impressum von DachrinneCheck – Dachrinnenservice für Willich, Krefeld, Düsseldorf und ganz Nordrhein-Westfalen." />
-  <meta property="og:url" content="https://www.dachrinnecheck.de/impressum.html" />
+  <meta property="og:url" content="https://www.dachrinnecheck.de/impressum" />
   <meta property="og:type" content="article" />
   <meta property="og:locale" content="de_DE" />
   <meta property="og:site_name" content="DachrinneCheck" />
   <meta property="og:image" content="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png" />
   <meta property="og:image:alt" content="Sauber gereinigte Dachrinne an einem Einfamilienhaus in Willich" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:url" content="https://www.dachrinnecheck.de/impressum.html" />
+  <meta name="twitter:url" content="https://www.dachrinnecheck.de/impressum" />
   <meta name="twitter:title" content="Impressum DachrinneCheck NRW | Dachrinnenservice" />
   <meta name="twitter:description" content="Impressum von DachrinneCheck – Dachrinnenservice für Willich, Krefeld, Düsseldorf und ganz Nordrhein-Westfalen." />
   <meta name="twitter:image" content="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png" />
@@ -128,18 +128,18 @@
   <div class="relative w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }" x-on:responsive-nav-toggle.window="mobileMenuOpen = $event.detail.open">
     <header @scroll.window="scrolled = window.scrollY &gt; 10" class="sticky top-0 z-30 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg shadow-md transition-all duration-300 responsive-header" data-responsive-header x-data="{ scrolled: false }">
       <div class="container mx-auto flex justify-between items-center px-4 py-4 md:py-5" data-nav-inner>
-        <a class="inline-flex items-center" data-nav-logo href="index.html">
+        <a class="inline-flex items-center" data-nav-logo href="/">
           <img alt="DachrinneCheck Logo für Dachrinnenreinigung NRW" class="h-16 md:h-20 w-auto" loading="lazy" src="https://static.wixstatic.com/media/6d33a0_2f72c9b480724f2b83a3784dddd3aa8f~mv2.png"/>
           <span class="sr-only">Zur Startseite</span>
         </a>
         <div class="hidden md:flex items-center gap-6 lg:gap-8 nav-inline" data-nav-inline>
-          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="index.html#services">Services</a>
-          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="index.html#about">Über uns</a>
-          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="index.html#contact">Kontakt</a>
-          <a class="bg-primary text-white font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base hover:bg-primary-dark transition-all duration-300 shadow transform hover:scale-105" href="kostenrechner.html">
+            <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="/#services">Services</a>
+            <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="/#about">Über uns</a>
+            <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="/#contact">Kontakt</a>
+          <a class="bg-primary text-white font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base hover:bg-primary-dark transition-all duration-300 shadow transform hover:scale-105" href="/kostenrechner">
             Zum Kostenrechner
           </a>
-          <a class="bg-white text-primary font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow-sm" href="index.html#contact">
+          <a class="bg-white text-primary font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow-sm" href="/#contact">
             Angebot anfordern
           </a>
         </div>
@@ -158,15 +158,15 @@
           </button>
           <div class="flex flex-col items-center space-y-4 py-4 border-t border-gray-200 dark:border-gray-700 nav-dialog-content">
             <div class="nav-dialog-links w-full flex flex-col items-center space-y-4">
-              <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="index.html#services">Services</a>
-              <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="index.html#about">Über uns</a>
-              <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="index.html#contact">Kontakt</a>
+                <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="/#services">Services</a>
+                <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="/#about">Über uns</a>
+                <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="/#contact">Kontakt</a>
             </div>
             <div class="nav-dialog-actions w-full flex flex-col items-center space-y-3">
-              <a @click="mobileMenuOpen = false" class="bg-primary text-white font-semibold py-3 px-8 rounded-full text-base hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105 mt-2 w-full" data-nav-close href="kostenrechner.html">
+              <a @click="mobileMenuOpen = false" class="bg-primary text-white font-semibold py-3 px-8 rounded-full text-base hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105 mt-2 w-full" data-nav-close href="/kostenrechner">
                 Zum Kostenrechner
               </a>
-              <a @click="mobileMenuOpen = false" class="bg-white text-primary font-semibold py-3 px-8 rounded-full text-base border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow mt-2 w-full" data-nav-close href="index.html#contact">
+                <a @click="mobileMenuOpen = false" class="bg-white text-primary font-semibold py-3 px-8 rounded-full text-base border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow mt-2 w-full" data-nav-close href="/#contact">
                 Angebot anfordern
               </a>
             </div>
@@ -245,10 +245,10 @@
     <footer class="bg-card-dark border-t border-gray-800 py-10 md:py-12">
       <div class="container mx-auto px-4 text-center text-text-dark">
         <div class="flex flex-col md:flex-row justify-center items-center space-y-4 md:space-y-0 md:space-x-8 mb-8">
-          <a class="hover:text-primary transition-colors text-sm" href="./datenschutz.html">Datenschutz</a>
-          <a class="hover:text-primary transition-colors text-sm" href="./impressum.html">Impressum</a>
-          <a class="hover:text-primary transition-colors text-sm" href="kostenrechner.html">Kostenrechner</a>
-          <a class="hover:text-primary transition-colors text-sm" href="index.html#contact">Kontakt</a>
+          <a class="hover:text-primary transition-colors text-sm" href="/datenschutz">Datenschutz</a>
+          <a class="hover:text-primary transition-colors text-sm" href="/impressum">Impressum</a>
+          <a class="hover:text-primary transition-colors text-sm" href="/kostenrechner">Kostenrechner</a>
+          <a class="hover:text-primary transition-colors text-sm" href="/#contact">Kontakt</a>
         </div>
         <p class="text-xs">© 2024 DachrinneCheck. Alle Rechte vorbehalten.</p>
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -262,15 +262,15 @@
   <div class="relative z-10 w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }" x-on:responsive-nav-toggle.window="mobileMenuOpen = $event.detail.open">
 <header @scroll.window="scrolled = window.scrollY &gt; 10" class="sticky top-0 z-30 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg shadow-md transition-all duration-300 responsive-header" data-responsive-header x-data="{ scrolled: false }">
 <div class="container mx-auto flex justify-between items-center px-4 py-4 md:py-5" data-nav-inner>
-<a class="inline-flex items-center" data-nav-logo href="index.html">
+        <a class="inline-flex items-center" data-nav-logo href="/">
 <img alt="DachrinneCheck Logo für Dachrinnenreinigung in NRW" class="h-16 md:h-20 w-auto" loading="lazy" src="https://static.wixstatic.com/media/6d33a0_2f72c9b480724f2b83a3784dddd3aa8f~mv2.png"/>
 <span class="sr-only">Zur Startseite</span>
 </a>
 <div class="hidden md:flex items-center gap-6 lg:gap-8 nav-inline" data-nav-inline>
-<a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="index.html#services">Services</a>
-<a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="index.html#about">Über uns</a>
+<a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="#services">Services</a>
+<a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="#about">Über uns</a>
 <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="#contact">Kontakt</a>
-<a class="bg-primary text-white font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base hover:bg-primary-dark transition-all duration-300 shadow transform hover:scale-105" href="kostenrechner.html">
+          <a class="bg-primary text-white font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base hover:bg-primary-dark transition-all duration-300 shadow transform hover:scale-105" href="/kostenrechner">
               Zum Kostenrechner
             </a>
 <a class="bg-white text-primary font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow-sm" href="#contact">
@@ -292,12 +292,12 @@
 </button>
 <div class="flex flex-col items-center space-y-4 py-4 border-t border-gray-200 dark:border-gray-700 nav-dialog-content">
 <div class="nav-dialog-links w-full flex flex-col items-center space-y-4">
-<a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="index.html#services">Services</a>
-<a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="index.html#about">Über uns</a>
+<a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="#services">Services</a>
+<a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="#about">Über uns</a>
 <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="#contact">Kontakt</a>
 </div>
 <div class="nav-dialog-actions w-full flex flex-col items-center space-y-3">
-<a @click="mobileMenuOpen = false" class="bg-primary text-white font-semibold py-3 px-8 rounded-full text-base hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105 mt-2 w-full" data-nav-close href="kostenrechner.html">
+              <a @click="mobileMenuOpen = false" class="bg-primary text-white font-semibold py-3 px-8 rounded-full text-base hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105 mt-2 w-full" data-nav-close href="/kostenrechner">
                   Zum Kostenrechner
                 </a>
 <a @click="mobileMenuOpen = false" class="bg-white text-primary font-semibold py-3 px-8 rounded-full text-base border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow mt-2 w-full" data-nav-close href="#contact">
@@ -318,7 +318,7 @@
 <h1 class="hero-heading font-black leading-tight tracking-tight text-shadow mb-4 md:mb-6 max-w-3xl mx-auto md:mx-0">Dachrinnenreinigung in NRW – sauber, sicher und termintreu</h1>
 <p class="text-lg md:text-2xl mb-8 md:mb-10 font-light text-shadow text-slate-100 max-w-2xl mx-auto md:mx-0">Wir halten Dachrinnen in Willich, Krefeld, Düsseldorf und ganz NRW frei von Schmutz – zuverlässig, sicher und mit moderner Ausrüstung. Nutzen Sie unseren Kostenrechner und erhalten Sie Ihr Angebot innerhalb von 24 Stunden.</p>
 <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-center md:justify-start md:items-center">
-          <a class="bg-primary text-white font-bold py-3 px-6 md:py-4 md:px-8 rounded-full text-base md:text-lg hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105 text-center w-full sm:w-auto" href="kostenrechner.html">
+          <a class="bg-primary text-white font-bold py-3 px-6 md:py-4 md:px-8 rounded-full text-base md:text-lg hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105 text-center w-full sm:w-auto" href="/kostenrechner">
             Zum Kostenrechner
           </a>
           <a class="bg-white text-primary font-bold py-3 px-6 md:py-4 md:px-8 rounded-full text-base md:text-lg border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow-lg transform hover:scale-105 text-center w-full sm:w-auto" href="#contact">
@@ -332,7 +332,7 @@
 <div class="text-center max-w-3xl mx-auto">
 <h2 class="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4 md:mb-6">Über DachrinneCheck</h2>
 <p class="text-base md:text-lg text-text-light dark:text-text-dark leading-relaxed">
-            Bei DachrinneCheck verbinden wir regionale Nähe mit moderner Reinigungstechnik. Wir entfernen Laub, Schmutz und Ablagerungen schonend, prüfen Übergänge sowie Fallrohre und sichern Ihr Gebäude zuverlässig gegen Wasserschäden ab. Persönliche Ansprechpartner, transparente Kommunikation und unser <a class="text-primary hover:text-primary-dark font-semibold" href="kostenrechner.html">Dachrinnenreinigung Kostenrechner</a> sorgen dafür, dass Sie jederzeit wissen, woran Sie sind.
+            Bei DachrinneCheck verbinden wir regionale Nähe mit moderner Reinigungstechnik. Wir entfernen Laub, Schmutz und Ablagerungen schonend, prüfen Übergänge sowie Fallrohre und sichern Ihr Gebäude zuverlässig gegen Wasserschäden ab. Persönliche Ansprechpartner, transparente Kommunikation und unser <a class="text-primary hover:text-primary-dark font-semibold" href="/kostenrechner">Dachrinnenreinigung Kostenrechner</a> sorgen dafür, dass Sie jederzeit wissen, woran Sie sind.
           </p>
 </div>
 </div>
@@ -525,7 +525,7 @@ Original lesen
 </svg>
 </button>
 <div class="px-4 md:px-6 pb-4 md:pb-6 text-text-light dark:text-text-dark text-sm md:text-base" x-show="open === 3" x-transition:enter="transition ease-out duration-300" x-transition:enter-end="opacity-100 translate-y-0" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:leave="transition ease-in duration-200" x-transition:leave-end="opacity-0 -translate-y-2" x-transition:leave-start="opacity-100 translate-y-0">
-<p>Die Kosten unseres Service hängen von mehreren Faktoren ab, darunter die Länge Ihrer Dachrinnen, die Höhe Ihres Gebäudes und die Menge an Schmutz. Nutzen Sie gern unseren <a class="text-primary hover:text-primary-dark font-semibold" href="kostenrechner.html">Kostenrechner</a>, um in wenigen Sekunden einen transparenten Richtpreis zu erhalten. Anschließend erstellen wir Ihnen ein kostenloses, unverbindliches Angebot, damit Sie den genauen Preis im Voraus kennen.</p>
+        <p>Die Kosten unseres Service hängen von mehreren Faktoren ab, darunter die Länge Ihrer Dachrinnen, die Höhe Ihres Gebäudes und die Menge an Schmutz. Nutzen Sie gern unseren <a class="text-primary hover:text-primary-dark font-semibold" href="/kostenrechner">Kostenrechner</a>, um in wenigen Sekunden einen transparenten Richtpreis zu erhalten. Anschließend erstellen wir Ihnen ein kostenloses, unverbindliches Angebot, damit Sie den genauen Preis im Voraus kennen.</p>
 </div>
 </div>
 </div>
@@ -630,7 +630,7 @@ Original lesen
 
   <div class="flex items-start gap-3">
     <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" id="consent" name="consent" required="" type="checkbox"/>
-    <label class="text-sm text-gray-700 dark:text-gray-300" for="consent">Ich habe die <a class="text-primary hover:text-primary-dark font-medium" href="./datenschutz.html" target="_blank" rel="noopener">Datenschutzerklärung</a> zur Kenntnis genommen.</label>
+    <label class="text-sm text-gray-700 dark:text-gray-300" for="consent">Ich habe die <a class="text-primary hover:text-primary-dark font-medium" href="/datenschutz" target="_blank" rel="noopener">Datenschutzerklärung</a> zur Kenntnis genommen.</label>
   </div>
 
   <div class="text-center pt-4">
@@ -640,7 +640,7 @@ Original lesen
   </div>
 </form>
 <div class="mt-10 text-center">
-    <a class="inline-flex items-center justify-center bg-primary text-white font-semibold py-3 px-8 md:py-4 md:px-10 rounded-full text-base md:text-lg hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105" href="kostenrechner.html">
+    <a class="inline-flex items-center justify-center bg-primary text-white font-semibold py-3 px-8 md:py-4 md:px-10 rounded-full text-base md:text-lg hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105" href="/kostenrechner">
       Zum Kostenrechner
     </a>
   </div>
@@ -650,9 +650,9 @@ Original lesen
 <footer class="bg-card-dark border-t border-gray-800 py-10 md:py-12">
 <div class="container mx-auto px-4 text-center text-text-dark">
 <div class="flex flex-col md:flex-row justify-center items-center space-y-4 md:space-y-0 md:space-x-8 mb-8">
-<a class="hover:text-primary transition-colors text-sm" href="./datenschutz.html">Datenschutz</a>
-<a class="hover:text-primary transition-colors text-sm" href="./impressum.html">Impressum</a>
-<a class="hover:text-primary transition-colors text-sm" href="kostenrechner.html">Kostenrechner</a>
+<a class="hover:text-primary transition-colors text-sm" href="/datenschutz">Datenschutz</a>
+<a class="hover:text-primary transition-colors text-sm" href="/impressum">Impressum</a>
+<a class="hover:text-primary transition-colors text-sm" href="/kostenrechner">Kostenrechner</a>
 <a class="hover:text-primary transition-colors text-sm" href="#contact">Kontakt</a>
 </div>
 <p class="text-xs">© 2024 DachrinneCheck. Alle Rechte vorbehalten.</p>

--- a/docs/kostenrechner.html
+++ b/docs/kostenrechner.html
@@ -6,7 +6,7 @@
   <base href="https://www.dachrinnecheck.de/" />
   <title>Preisrechner Dachrinnenreinigung NRW | DachrinneCheck</title>
   <meta name="description" content="Berechnen Sie die Kosten für Ihre Dachrinnenreinigung in Willich, Krefeld, Düsseldorf &amp; ganz NRW. Der DachrinneCheck Preisrechner liefert transparente Richtpreise für Dachrinne Reinigen, Laubschutz &amp; Service." />
-  <link rel="canonical" href="https://www.dachrinnecheck.de/kostenrechner.html" />
+  <link rel="canonical" href="https://www.dachrinnecheck.de/kostenrechner" />
   <meta name="robots" content="index,follow" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -14,14 +14,14 @@
   <link rel="icon" type="image/svg+xml" href="assets/img/dachrinnecheck-logo.svg" />
   <meta property="og:title" content="Preisrechner Dachrinnenreinigung NRW | DachrinneCheck" />
   <meta property="og:description" content="Berechnen Sie die Kosten für Ihre Dachrinnenreinigung in Willich, Krefeld, Düsseldorf &amp; ganz NRW. Der DachrinneCheck Preisrechner liefert transparente Richtpreise für Dachrinne Reinigen, Laubschutz &amp; Service." />
-  <meta property="og:url" content="https://www.dachrinnecheck.de/kostenrechner.html" />
+  <meta property="og:url" content="https://www.dachrinnecheck.de/kostenrechner" />
   <meta property="og:type" content="website" />
   <meta property="og:locale" content="de_DE" />
   <meta property="og:site_name" content="DachrinneCheck" />
   <meta property="og:image" content="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png" />
   <meta property="og:image:alt" content="Sauber gereinigte Dachrinne an einem Einfamilienhaus in Willich" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:url" content="https://www.dachrinnecheck.de/kostenrechner.html" />
+  <meta name="twitter:url" content="https://www.dachrinnecheck.de/kostenrechner" />
   <meta name="twitter:title" content="Preisrechner Dachrinnenreinigung NRW | DachrinneCheck" />
   <meta name="twitter:description" content="Berechnen Sie die Kosten für Ihre Dachrinnenreinigung in Willich, Krefeld, Düsseldorf &amp; ganz NRW. Der DachrinneCheck Preisrechner liefert transparente Richtpreise für Dachrinne Reinigen, Laubschutz &amp; Service." />
   <meta name="twitter:image" content="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png" />
@@ -368,15 +368,15 @@
   <div class="relative w-full overflow-x-hidden" x-data="{ mobileMenuOpen: false }" x-on:responsive-nav-toggle.window="mobileMenuOpen = $event.detail.open">
     <header @scroll.window="scrolled = window.scrollY &gt; 10" class="sticky top-0 z-30 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg shadow-md transition-all duration-300 responsive-header" data-responsive-header x-data="{ scrolled: false }">
       <div class="container mx-auto flex justify-between items-center px-4 py-4 md:py-5" data-nav-inner>
-        <a class="inline-flex items-center" data-nav-logo href="index.html">
+        <a class="inline-flex items-center" data-nav-logo href="/">
           <img alt="DachrinneCheck Logo für Dachrinnenreinigung NRW" class="h-16 md:h-20 w-auto" loading="lazy" src="https://static.wixstatic.com/media/6d33a0_2f72c9b480724f2b83a3784dddd3aa8f~mv2.png"/>
           <span class="sr-only">Zur Startseite</span>
         </a>
         <div class="hidden md:flex items-center gap-6 lg:gap-8 nav-inline" data-nav-inline>
-          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="index.html#services">Services</a>
-          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="index.html#about">Über uns</a>
+          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="/#services">Services</a>
+          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="/#about">Über uns</a>
           <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="#contact">Kontakt</a>
-          <a class="bg-primary text-white font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base hover:bg-primary-dark transition-all duration-300 shadow transform hover:scale-105" href="kostenrechner.html">
+          <a class="bg-primary text-white font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base hover:bg-primary-dark transition-all duration-300 shadow transform hover:scale-105" href="/kostenrechner">
             Zum Kostenrechner
           </a>
           <a class="bg-white text-primary font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow-sm" href="#contact">
@@ -398,12 +398,12 @@
           </button>
           <div class="flex flex-col items-center space-y-4 py-4 border-t border-gray-200 dark:border-gray-700 nav-dialog-content">
             <div class="nav-dialog-links w-full flex flex-col items-center space-y-4">
-              <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="index.html#services">Services</a>
-              <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="index.html#about">Über uns</a>
+              <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="/#services">Services</a>
+              <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="/#about">Über uns</a>
               <a @click="mobileMenuOpen = false" class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="#contact">Kontakt</a>
             </div>
             <div class="nav-dialog-actions w-full flex flex-col items-center space-y-3">
-              <a @click="mobileMenuOpen = false" class="bg-primary text-white font-semibold py-3 px-8 rounded-full text-base hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105 mt-2 w-full" data-nav-close href="kostenrechner.html">
+              <a @click="mobileMenuOpen = false" class="bg-primary text-white font-semibold py-3 px-8 rounded-full text-base hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105 mt-2 w-full" data-nav-close href="/kostenrechner">
                 Zum Kostenrechner
               </a>
               <a @click="mobileMenuOpen = false" class="bg-white text-primary font-semibold py-3 px-8 rounded-full text-base border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow mt-2 w-full" data-nav-close href="#contact">
@@ -530,7 +530,7 @@
                   <label for="cbConsent" class="note">
                     Ich willige ein, dass meine Angaben zur Kontaktaufnahme, Angebotserstellung und Terminabstimmung verarbeitet und gespeichert werden.
                     Die Einwilligung kann ich jederzeit mit Wirkung für die Zukunft widerrufen. Hinweise in der
-                    <a href="datenschutz.html" target="_blank" rel="noopener">Datenschutzerklärung</a>.
+                    <a href="/datenschutz" target="_blank" rel="noopener">Datenschutzerklärung</a>.
                   </label>
                 </div>
 
@@ -564,9 +564,9 @@
     <footer class="bg-card-dark border-t border-gray-800 py-10 md:py-12">
       <div class="container mx-auto px-4 text-center text-text-dark">
         <div class="flex flex-col md:flex-row justify-center items-center space-y-4 md:space-y-0 md:space-x-8 mb-8">
-          <a class="hover:text-primary transition-colors text-sm" href="./datenschutz.html">Datenschutz</a>
-          <a class="hover:text-primary transition-colors text-sm" href="./impressum.html">Impressum</a>
-          <a class="hover:text-primary transition-colors text-sm" href="kostenrechner.html">Kostenrechner</a>
+          <a class="hover:text-primary transition-colors text-sm" href="/datenschutz">Datenschutz</a>
+          <a class="hover:text-primary transition-colors text-sm" href="/impressum">Impressum</a>
+          <a class="hover:text-primary transition-colors text-sm" href="/kostenrechner">Kostenrechner</a>
           <a class="hover:text-primary transition-colors text-sm" href="#contact">Kontakt</a>
         </div>
         <p class="text-xs">© 2024 DachrinneCheck. Alle Rechte vorbehalten.</p>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -7,19 +7,19 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://www.dachrinnecheck.de/kostenrechner.html</loc>
+    <loc>https://www.dachrinnecheck.de/kostenrechner</loc>
     <lastmod>2025-09-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.dachrinnecheck.de/impressum.html</loc>
+    <loc>https://www.dachrinnecheck.de/impressum</loc>
     <lastmod>2025-09-19</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
-    <loc>https://www.dachrinnecheck.de/datenschutz.html</loc>
+    <loc>https://www.dachrinnecheck.de/datenschutz</loc>
     <lastmod>2025-09-19</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>


### PR DESCRIPTION
## Summary
- update navigation and footer links to drop the .html suffix in favor of extensionless paths
- align canonical links and references with the new extensionless URLs across all static pages

## Testing
- not run (static HTML changes)


------
https://chatgpt.com/codex/tasks/task_b_68cdcac8106c8329aa4d3484e31da383