### PR TITLE
Modularize landing page into HTML partials

### DIFF
--- a/docs/assets/js/responsive-nav.js
+++ b/docs/assets/js/responsive-nav.js
@@ -1,12 +1,12 @@
-(function () {
-  const headers = Array.from(document.querySelectorAll('[data-responsive-header]'));
-  if (!headers.length) {
-    return;
-  }
 
+(function () {
   const focusableSelectors = 'a[href]:not([tabindex="-1"]), button:not([disabled]):not([tabindex="-1"]), [tabindex]:not([tabindex="-1"]), input:not([disabled]):not([tabindex="-1"]), select:not([disabled]):not([tabindex="-1"]), textarea:not([disabled]):not([tabindex="-1"])';
 
-  headers.forEach((header) => {
+  const initHeader = (header) => {
+    if (header.dataset.responsiveNavReady === 'true') {
+      return;
+    }
+
     const navInner = header.querySelector('[data-nav-inner]') || header;
     const inlineNav = header.querySelector('[data-nav-inline]');
     const logoLink = header.querySelector('[data-nav-logo]');
@@ -19,9 +19,10 @@
       return;
     }
 
+    header.dataset.responsiveNavReady = 'true';
+
     let lastFocused = null;
 
-    // FIX: Always keep ARIA attributes in sync with the open state
     const setAriaState = (expanded) => {
       toggleButton.setAttribute('aria-expanded', expanded ? 'true' : 'false');
       const openLabel = toggleButton.dataset.navLabelOpen || 'Menü öffnen';
@@ -30,7 +31,6 @@
       dialog.setAttribute('aria-hidden', expanded ? 'false' : 'true');
     };
 
-    // FIX: Trap focus inside the fly-out while it is open
     const trapFocus = (event) => {
       if (event.key !== 'Tab' || !header.classList.contains('menu-open')) {
         return;
@@ -101,7 +101,6 @@
       });
     };
 
-    // FIX: Collapse the inline nav as soon as layout space runs out
     const updateCollapse = () => {
       const previousState = header.classList.contains('is-collapsed');
       header.classList.remove('is-collapsed');
@@ -198,7 +197,18 @@
     if (document.fonts && document.fonts.addEventListener) {
       document.fonts.addEventListener('loadingdone', updateCollapse, { once: false });
     }
+  };
 
-    updateCollapse();
-  });
+  const initHeaders = () => {
+    const headers = Array.from(document.querySelectorAll('[data-responsive-header]'));
+    headers.forEach(initHeader);
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initHeaders);
+  } else {
+    initHeaders();
+  }
+
+  document.addEventListener('partials:loaded', initHeaders);
 })();

--- a/docs/index.html
+++ b/docs/index.html
@@ -111,426 +111,23 @@
   </style>
   </head>
 <body class="bg-background-light dark:bg-background-dark font-display">
-<div class="relative w-full overflow-x-hidden">
-<!-- FIX: Shared navigation rebuilt for consistent behaviour across pages -->
-<header class="sticky top-0 z-30 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg shadow-md transition-all duration-300 responsive-header" data-responsive-header>
-<div class="container mx-auto flex justify-between items-center px-4 py-4 md:py-5" data-nav-inner>
-<a class="inline-flex items-center" data-nav-logo href="https://www.dachrinnecheck.de/">
-<img alt="DachrinneCheck Logo" src="https://static.wixstatic.com/media/6d33a0_2f72c9b480724f2b83a3784dddd3aa8f~mv2.png"/>
-<span class="sr-only">Zur Startseite</span>
-</a>
-<nav aria-label="Hauptnavigation" class="hidden md:flex items-center gap-5 lg:gap-8 nav-inline" data-nav-inline>
-<a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="https://www.dachrinnecheck.de/#services">Services</a>
-<a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="https://www.dachrinnecheck.de/#about">Über uns</a>
-<a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="https://www.dachrinnecheck.de/#contact">Kontakt</a>
-<a class="bg-primary text-white font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base hover:bg-primary-dark transition-all duration-300 shadow transform hover:scale-105" href="https://www.dachrinnecheck.de/kostenrechner">
-              Zum Kostenrechner
-            </a>
-<a class="bg-white text-primary font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow-sm" href="https://www.dachrinnecheck.de/#contact">
-              Angebot anfordern
-            </a>
-</nav>
-<div class="nav-toggle">
-<button aria-controls="primary-navigation" aria-expanded="false" class="text-gray-900 dark:text-white" data-nav-label-close="Menü schließen" data-nav-label-open="Menü öffnen" data-nav-toggle type="button">
-<span aria-hidden="true" class="material-symbols-outlined text-3xl">menu</span>
-<span class="sr-only">Menü</span>
-</button>
-</div>
-</div>
-<div class="nav-dialog-backdrop" data-nav-overlay hidden>
-<nav aria-hidden="true" aria-label="Mobile Navigation" aria-modal="true" class="nav-dialog" data-nav-dialog id="primary-navigation" role="dialog" tabindex="-1">
-<button class="nav-dialog-close text-gray-900 dark:text-text-dark p-2" data-nav-close type="button">
-<span aria-hidden="true" class="material-symbols-outlined text-2xl">close</span>
-<span class="sr-only">Menü schließen</span>
-</button>
-<div class="flex flex-col items-center space-y-4 py-4 border-t border-gray-200 dark:border-gray-700 nav-dialog-content">
-<div class="nav-dialog-links w-full flex flex-col items-center space-y-4">
-<a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="https://www.dachrinnecheck.de/#services">Services</a>
-<a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="https://www.dachrinnecheck.de/#about">Über uns</a>
-<a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="https://www.dachrinnecheck.de/#contact">Kontakt</a>
-</div>
-<div class="nav-dialog-actions w-full flex flex-col items-center space-y-3">
-<a class="bg-primary text-white font-semibold py-3 px-8 rounded-full text-base hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105 mt-2 w-full" data-nav-close href="https://www.dachrinnecheck.de/kostenrechner">
-                  Zum Kostenrechner
-                </a>
-<a class="bg-white text-primary font-semibold py-3 px-8 rounded-full text-base border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow mt-2 w-full" data-nav-close href="https://www.dachrinnecheck.de/#contact">
-                  Angebot anfordern
-                </a>
-</div>
-</div>
-</nav>
-</div>
-</header>
-<!-- FIX: Static hero background eliminates black bars on scroll -->
-<section class="relative text-white hero-section">
-<div aria-hidden="true" class="hero-media">
-<img alt="Arbeiter reinigt Dachrinne auf einem Gebäude" loading="lazy" src="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png"/>
-</div>
-<div class="hero-overlay" aria-hidden="true"></div>
-<div class="relative z-10 hero-content">
-<h1 class="text-4xl md:text-6xl lg:text-7xl font-black leading-tight tracking-tight mb-4 md:mb-6 text-shadow">Professionelle Dachrinnenreinigung in NRW</h1>
-<p class="text-lg md:text-2xl mb-8 md:mb-10 text-shadow font-light">Schützen Sie Ihr Eigentum vor Wasserschäden. Fordern Sie noch heute ein kostenloses Angebot an.</p>
-<div class="flex flex-col sm:flex-row gap-4">
-          <a class="bg-primary text-white font-bold py-3 px-6 md:py-4 md:px-8 rounded-full text-base md:text-lg hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105 text-center" href="https://www.dachrinnecheck.de/kostenrechner">
-            Zum Kostenrechner
-          </a>
-          <a class="bg-white text-primary font-bold py-3 px-6 md:py-4 md:px-8 rounded-full text-base md:text-lg border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow-lg transform hover:scale-105 text-center" href="https://www.dachrinnecheck.de/#contact">
-            Angebot anfordern
-          </a>
-        </div>
-</div>
-</section>
-<section class="py-16 md:py-20 px-4 bg-card-light dark:bg-card-dark reveal" id="about">
-<div class="container mx-auto">
-<div class="text-center max-w-3xl mx-auto">
-<h2 class="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4 md:mb-6">Über DachrinneCheck</h2>
-<p class="text-base md:text-lg text-text-light dark:text-text-dark leading-relaxed">
-            Willkommen bei DachrinneCheck, Ihrem zuverlässigen Partner für professionelle Dachrinnenreinigung in Nordrhein-Westfalen. Unsere Mission ist es, Ihr Zuhause vor Wasserschäden zu schützen, indem wir sicherstellen, dass Ihre Dachrinnen sauber, frei und voll funktionsfähig sind. Wir verpflichten uns zu qualitativ hochwertigem Service mit Fokus auf Zuverlässigkeit, Effizienz und Kundenzufriedenheit.
-          </p>
-</div>
-</div>
-</section>
-<section class="py-16 md:py-20 px-4 bg-background-light dark:bg-background-dark reveal">
-<div class="container mx-auto">
-<div class="text-center max-w-3xl mx-auto mb-12 md:mb-16">
-<h2 class="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4 md:mb-6">Sehen Sie unsere Arbeit in Aktion</h2>
-<p class="text-base md:text-lg text-text-light dark:text-text-dark">Schauen Sie sich unser Video an, um einen Einblick in unseren professionellen Reinigungsprozess und die Ergebnisse zu erhalten, die wir liefern.</p>
-</div>
-<div class="max-w-4xl mx-auto">
-          <div class="rounded-xl overflow-hidden shadow-custom hover-lift">
-            <div class="relative w-full" style="padding-top: 56.25%;">
-              <video class="absolute inset-0 w-full h-full object-cover" controls preload="metadata" playsinline>
-                <source src="https://video.wixstatic.com/video/6d33a0_8388ea3febb544bba1a01ab1de3c0b1a/720p/mp4/file.mp4" type="video/mp4"/>
-                Ihr Browser unterstützt das Abspielen dieses Videos nicht.
-              </video>
-            </div>
-          </div>
-        </div>
-</div>
-</section>
-<section class="py-16 md:py-20 px-4 bg-card-light dark:bg-card-dark reveal">
-<div class="container mx-auto">
-<div class="text-center max-w-3xl mx-auto mb-12 md:mb-16">
-<h2 class="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4 md:mb-6">Sehen Sie den Unterschied</h2>
-<p class="text-base md:text-lg text-text-light dark:text-text-dark">Unsere Vorher-Nachher-Galerie zeigt die Qualität und Effektivität unserer Dienstleistungen.</p>
-</div>
-<div class="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-10">
-<div class="rounded-xl overflow-hidden shadow-custom bg-card-light dark:bg-card-dark hover-lift reveal">
-<div class="relative">
-<img alt="Gutter before cleaning" class="w-full h-64 md:h-72 object-cover" src="https://static.wixstatic.com/media/6d33a0_e6c8065853f1475d97141c103c8f38a5~mv2.png"/>
-<div class="absolute top-4 left-4 bg-red-500/80 text-white px-4 py-1 rounded-full text-xs md:text-sm font-semibold">Vorher</div>
-</div>
-<div class="p-6">
-<h3 class="text-lg md:text-xl font-bold text-gray-900 dark:text-white mb-2">Verstopft und Überlaufend</h3>
-<p class="text-text-light dark:text-text-dark text-sm md:text-base">Laub, Moos und Schmutz blockierten die Dachrinne vollständig, was zu einem Überlaufen des Wassers führte.</p>
-</div>
-</div>
-<div class="rounded-xl overflow-hidden shadow-custom bg-card-light dark:bg-card-dark hover-lift reveal">
-<div class="relative">
-<img alt="Gutter after cleaning" class="w-full h-64 md:h-72 object-cover" src="https://static.wixstatic.com/media/6d33a0_b9208eaa790f49fcb1d72fa23dd847be~mv2.png"/>
-<div class="absolute top-4 left-4 bg-green-500/80 text-white px-4 py-1 rounded-full text-xs md:text-sm font-semibold">Nachher</div>
-</div>
-<div class="p-6">
-<h3 class="text-lg md:text-xl font-bold text-gray-900 dark:text-white mb-2">Sauber und Frei</h3>
-<p class="text-text-light dark:text-text-dark text-sm md:text-base">Nach unserem Service ist die Dachrinne vollständig frei, sodass das Wasser frei fließen kann.</p>
-</div>
-</div>
-</div>
-</div>
-</section>
-<section class="py-16 md:py-20 px-4 bg-background-light dark:bg-background-dark reveal" id="services">
-<div class="container mx-auto">
-<div class="text-center max-w-3xl mx-auto mb-12 md:mb-16">
-<h2 class="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4 md:mb-6">Umfassende Dachrinnenpflege</h2>
-<p class="text-base md:text-lg text-text-light dark:text-text-dark">Wir bieten eine Reihe von Dienstleistungen an, um sicherzustellen, dass Ihre Dachrinnen in Top-Zustand sind.</p>
-</div>
-<div class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
-<div class="bg-card-light dark:bg-card-dark p-8 rounded-xl text-center border border-gray-200 dark:border-gray-700 hover-lift reveal">
-<div class="flex justify-center mb-5 text-primary">
-<svg fill="currentColor" height="48" viewBox="0 0 256 256" width="48" xmlns="http://www.w3.org/2000/svg">
-<path d="M218.83,103.77l-80-75.48a1.14,1.14,0,0,1-.11-.11,16,16,0,0,0-21.53,0l-.11.11L37.17,103.77A16,16,0,0,0,32,115.55V208a16,16,0,0,0,16,16H96a16,16,0,0,0,16-16V160h32v48a16,16,0,0,0,16,16h48a16,16,0,0,0,16-16V115.55A16,16,0,0,0,218.83,103.77ZM208,208H160V160a16,16,0,0,0-16-16H112a16,16,0,0,0-16,16v48H48V115.55l.11-.1L128,40l79.9,75.43.11.1Z"></path>
-</svg>
-</div>
-<h3 class="text-xl md:text-2xl font-bold text-gray-900 dark:text-white mb-3">Dachrinnenreinigung</h3>
-<p class="text-text-light dark:text-text-dark text-sm md:text-base">Gründliche Reinigung von Dachrinnen und Fallrohren, um Laub und Verstopfungen zu entfernen.</p>
-</div>
-<div class="bg-card-light dark:bg-card-dark p-8 rounded-xl text-center border border-gray-200 dark:border-gray-700 hover-lift reveal">
-<div class="flex justify-center mb-5 text-primary">
-<svg fill="currentColor" height="48" viewBox="0 0 256 256" width="48" xmlns="http://www.w3.org/2000/svg">
-<path d="M223.45,40.07a8,8,0,0,0-7.52-7.52C139.8,28.08,78.82,51,52.82,94a87.09,87.09,0,0,0-12.76,49c.57,15.92,5.21,32,13.79,47.85l-19.51,19.5a8,8,0,0,0,11.32,11.32l19.5-19.51C81,210.73,97.09,215.37,113,215.94q1.67.06,3.33.06A86.93,86.93,0,0,0,162,203.18C205,177.18,227.93,116.21,223.45,40.07ZM153.75,189.5c-22.75,13.78-49.68,14-76.71.77l88.63-88.62a8,8,0,0,0-11.32-11.32L65.73,179c-13.19-27-13-54,.77-76.71,22.09-36.47,74.6-56.44,141.31-54.06C210.2,114.89,190.22,167.41,153.75,189.5Z"></path>
-</svg>
-</div>
-<h3 class="text-xl md:text-2xl font-bold text-gray-900 dark:text-white mb-3">Schmutzentfernung</h3>
-<p class="text-text-light dark:text-text-dark text-sm md:text-base">Entfernung aller Abfälle von Ihrem Grundstück, damit es sauber und ordentlich bleibt.</p>
-</div>
-<div class="bg-card-light dark:bg-card-dark p-8 rounded-xl text-center border border-gray-200 dark:border-gray-700 hover-lift reveal">
-<div class="flex justify-center mb-5 text-primary">
-<svg fill="currentColor" height="48" viewBox="0 0 256 256" width="48" xmlns="http://www.w3.org/2000/svg">
-<path d="M208,40H48A16,16,0,0,0,32,56v58.78c0,89.61,75.82,119.34,91,124.39a15.53,15.53,0,0,0,10,0c15.2-5.05,91-34.78,91-124.39V56A16,16,0,0,0,208,40Zm0,74.79c0,78.42-66.35,104.62-80,109.18-13.53-4.51-80-30.69-80-109.18V56H208ZM82.34,141.66a8,8,0,0,1,11.32-11.32L112,148.68l50.34-50.34a8,8,0,0,1,11.32,11.32l-56,56a8,8,0,0,1-11.32,0Z"></path>
-</svg>
-</div>
-<h3 class="text-xl md:text-2xl font-bold text-gray-900 dark:text-white mb-3">Dachrinneninspektion</h3>
-<p class="text-text-light dark:text-text-dark text-sm md:text-base">Detaillierte Inspektion Ihrer Dachrinnen, um potenzielle Probleme oder Schäden zu identifizieren.</p>
-</div>
-</div>
-</div>
-</section>
 
-<section class="py-16 md:py-20 px-4 bg-card-light dark:bg-card-dark reveal">
-<div class="container mx-auto">
-<h2 class="text-3xl md:text-4xl font-bold text-center mb-4 md:mb-6 text-gray-900 dark:text-white">Was unsere Kunden sagen</h2>
-<p class="text-base md:text-lg text-text-light dark:text-text-dark text-center mb-8 md:mb-12 max-w-2xl mx-auto">Hören Sie von unseren zufriedenen Kunden und erfahren Sie, warum sie DachrinneCheck vertrauen.</p>
-<div class="relative max-w-3xl mx-auto" x-data="reviewsCarousel()" x-init="init()" x-cloak>
-<div class="bg-white/70 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 text-center rounded-xl py-8" x-show="!ready && !error">
-<p class="font-medium">Kundenstimmen werden geladen …</p>
+<div class="relative w-full overflow-x-hidden" data-page-wrapper>
+  <div data-include="partials/header.html"></div>
+  <main id="main-content" tabindex="-1">
+    <div data-include="partials/hero.html"></div>
+    <div data-include="partials/about.html"></div>
+    <div data-include="partials/video-showcase.html"></div>
+    <div data-include="partials/gallery.html"></div>
+    <div data-include="partials/services.html"></div>
+    <div data-include="partials/testimonials.html"></div>
+    <div data-include="partials/faq.html"></div>
+    <div data-include="partials/contact.html"></div>
+  </main>
+  <div data-include="partials/footer.html"></div>
 </div>
-<div class="bg-red-50 border border-red-200 text-red-700 dark:bg-red-900/30 dark:border-red-700 dark:text-red-200 rounded-xl p-6 text-center" x-show="error" x-transition>
-<p class="font-semibold" x-text="error"></p>
-</div>
-<div @mouseenter="stopAutoRotate()" @mouseleave="startAutoRotate()" class="relative" x-show="ready" x-transition>
-<div class="overflow-hidden">
-<div :style="`transform: translateX(-${activeIndex * 100}%)`" class="flex transition-transform duration-500 ease-in-out">
-<template x-for="(review, index) in reviews" :key="review.id || index">
-<div class="flex-shrink-0 w-full p-2">
-<div class="bg-background-light dark:bg-background-dark rounded-xl shadow-custom p-6 md:p-8 text-center hover-lift relative">
-<template x-if="review.highlighted">
-<span class="absolute top-4 right-4 bg-primary text-white text-xs font-semibold uppercase tracking-wide px-3 py-1 rounded-full">Top-Bewertung</span>
-</template>
-<div class="flex justify-center mb-4">
-<img :alt="`Avatar von ${review.name}`" :src="avatarUrl(review)" class="w-20 h-20 md:w-24 md:h-24 rounded-full object-cover border-4 border-white shadow"/>
-</div>
-<div class="flex flex-wrap justify-center items-center gap-2 mb-3" x-show="review.verified || review.source">
-<template x-if="review.verified">
-<span class="flex items-center text-xs font-semibold text-green-700 bg-green-100 dark:text-green-200 dark:bg-green-900/60 px-3 py-1 rounded-full">
-<span class="material-symbols-outlined text-base mr-1">verified</span>
-Verifiziert
-</span>
-</template>
-<template x-if="review.source">
-<span class="text-xs text-text-light dark:text-text-dark px-3 py-1 rounded-full border border-gray-200 dark:border-gray-700 bg-white/80 dark:bg-gray-800/70" x-text="review.source"></span>
-</template>
-</div>
-<div class="flex justify-center text-yellow-400 mb-4">
-<template x-for="star in 5" :key="`${review.id || index}-star-${star}`">
-<span class="material-symbols-outlined" x-text="starIcon(star, review.rating)"></span>
-</template>
-</div>
-<p class="text-base md:text-lg text-text-light dark:text-text-dark italic mb-4">&bdquo;<span x-text="review.text"></span>&ldquo;</p>
-<p class="font-bold text-gray-900 dark:text-white" x-text="review.name"></p>
-<p class="text-sm text-text-light dark:text-text-dark mb-3" x-text="formatMeta(review)"></p>
-<template x-if="review.link">
-<p class="text-sm">
-<a :href="review.link" class="text-primary hover:text-primary-dark font-medium inline-flex items-center gap-1" rel="noopener" target="_blank">
-Original lesen
-<span class="material-symbols-outlined text-base">open_in_new</span>
-</a>
-</p>
-</template>
-</div>
-</div>
-</template>
-</div>
-</div>
-<button :aria-disabled="reviews.length <= 1" :class="{'opacity-40 cursor-not-allowed': reviews.length <= 1}" @click="previous" class="absolute top-1/2 -translate-y-1/2 left-0 -translate-x-4 md:-translate-x-1/2 bg-white dark:bg-gray-800 rounded-full p-2 shadow-md hover:bg-gray-100 dark:hover:bg-gray-700 transition transform hover:scale-110" type="button">
-<span class="material-symbols-outlined text-primary">chevron_left</span>
-</button>
-<button :aria-disabled="reviews.length <= 1" :class="{'opacity-40 cursor-not-allowed': reviews.length <= 1}" @click="next" class="absolute top-1/2 -translate-y-1/2 right-0 translate-x-4 md:translate-x-1/2 bg-white dark:bg-gray-800 rounded-full p-2 shadow-md hover:bg-gray-100 dark:hover:bg-gray-700 transition transform hover:scale-110" type="button">
-<span class="material-symbols-outlined text-primary">chevron_right</span>
-</button>
-</div>
-  <div class="flex justify-center space-x-2 mt-6 md:mt-8" x-show="ready && reviews.length > 1">
-<template x-for="(review, index) in reviews" :key="`${review.id || index}-indicator`">
-<button :aria-label="`Bewertung ${index + 1} anzeigen`" :class="{'bg-primary scale-110': activeIndex === index, 'bg-gray-300 dark:bg-gray-600': activeIndex !== index}" @click="goTo(index)" class="w-3 h-3 rounded-full transition transform" type="button"></button>
-</template>
-  </div>
-  </div>
-  <div class="mt-12" id="dynamic-reviews">
-    <div class="text-center max-w-3xl mx-auto mb-8">
-      <h3 class="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white">Aktuelle Kundenbewertungen</h3>
-      <p class="text-base md:text-lg text-text-light dark:text-text-dark">Echte Rückmeldungen aus unserer Reviews-CMS-Sammlung – automatisch aktualisiert.</p>
-    </div>
-    <div class="max-w-4xl mx-auto space-y-6">
-      <div class="bg-white/70 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 rounded-xl p-6 text-center" id="reviews-loading">
-        <p class="font-medium">Bewertungen werden geladen …</p>
-      </div>
-      <div class="hidden bg-red-50 border border-red-200 text-red-700 dark:bg-red-900/30 dark:border-red-700 dark:text-red-200 rounded-xl p-6 text-center" id="reviews-error"></div>
-      <div class="hidden text-text-light dark:text-text-dark text-center" id="reviews-empty">Noch keine veröffentlichten Bewertungen vorhanden.</div>
-      <div class="grid gap-6 md:grid-cols-2" id="reviews-list"></div>
-    </div>
-  </div>
-  </div>
-</section>
 
-<section class="py-16 md:py-20 px-4 bg-background-light dark:bg-background-dark reveal">
-<div class="container mx-auto max-w-3xl">
-<h2 class="text-3xl md:text-4xl font-bold text-center text-gray-900 dark:text-white mb-8 md:mb-12">Häufig gestellte Fragen</h2>
-<div class="space-y-4 md:space-y-6" x-data="{ open: null }">
-<div class="bg-card-light dark:bg-card-dark rounded-xl shadow-sm hover-lift reveal">
-<button @click="open === 1 ? open = null : open = 1" class="w-full text-left p-4 md:p-6 flex justify-between items-center">
-<span class="font-semibold text-base md:text-xl text-gray-900 dark:text-white">Wie oft sollte ich meine Dachrinnen reinigen lassen?</span>
-<svg :class="{ 'rotate-180': open === 1 }" class="w-6 h-6 text-primary transform transition-transform duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-<path d="M19 9l-7 7-7-7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
-</svg>
-</button>
-<div class="px-4 md:px-6 pb-4 md:pb-6 text-text-light dark:text-text-dark text-sm md:text-base" x-show="open === 1" x-transition:enter="transition ease-out duration-300" x-transition:enter-end="opacity-100 translate-y-0" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:leave="transition ease-in duration-200" x-transition:leave-end="opacity-0 -translate-y-2" x-transition:leave-start="opacity-100 translate-y-0">
-<p>Wir empfehlen, Ihre Dachrinnen mindestens zweimal im Jahr reinigen zu lassen, typischerweise im Frühjahr und Herbst. Wenn Ihr Grundstück von vielen Bäumen umgeben ist, kann eine häufigere Reinigung erforderlich sein.</p>
-</div>
-</div>
-<div class="bg-card-light dark:bg-card-dark rounded-xl shadow-sm hover-lift reveal">
-<button @click="open === 2 ? open = null : open = 2" class="w-full text-left p-4 md:p-6 flex justify-between items-center">
-<span class="font-semibold text-base md:text-xl text-gray-900 dark:text-white">Was ist Ihr Servicegebiet in NRW?</span>
-<svg :class="{ 'rotate-180': open === 2 }" class="w-6 h-6 text-primary transform transition-transform duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-<path d="M19 9l-7 7-7-7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
-</svg>
-</button>
-<div class="px-4 md:px-6 pb-4 md:pb-6 text-text-light dark:text-text-dark text-sm md:text-base" x-show="open === 2" x-transition:enter="transition ease-out duration-300" x-transition:enter-end="opacity-100 translate-y-0" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:leave="transition ease-in duration-200" x-transition:leave-end="opacity-0 -translate-y-2" x-transition:leave-start="opacity-100 translate-y-0">
-<p>Wir bieten unsere Dachrinnenreinigungsdienste in der gesamten Region Nordrhein-Westfalen (NRW) an. Kontaktieren Sie uns mit Ihrer Adresse, um zu bestätigen, ob wir Ihren spezifischen Standort bedienen.</p>
-</div>
-</div>
-<div class="bg-card-light dark:bg-card-dark rounded-xl shadow-sm hover-lift reveal">
-<button @click="open === 3 ? open = null : open = 3" class="w-full text-left p-4 md:p-6 flex justify-between items-center">
-<span class="font-semibold text-base md:text-xl text-gray-900 dark:text-white">Wie wird der Preis für die Dachrinnenreinigung bestimmt?</span>
-<svg :class="{ 'rotate-180': open === 3 }" class="w-6 h-6 text-primary transform transition-transform duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-<path d="M19 9l-7 7-7-7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
-</svg>
-</button>
-<div class="px-4 md:px-6 pb-4 md:pb-6 text-text-light dark:text-text-dark text-sm md:text-base" x-show="open === 3" x-transition:enter="transition ease-out duration-300" x-transition:enter-end="opacity-100 translate-y-0" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:leave="transition ease-in duration-200" x-transition:leave-end="opacity-0 -translate-y-2" x-transition:leave-start="opacity-100 translate-y-0">
-<p>Die Kosten unseres Service hängen von mehreren Faktoren ab, darunter die Länge Ihrer Dachrinnen, die Höhe Ihres Gebäudes und die Menge an Schmutz. Nutzen Sie gern unseren <a class="text-primary hover:text-primary-dark font-semibold" href="https://www.dachrinnecheck.de/kostenrechner">Kostenrechner</a>, um in wenigen Sekunden einen transparenten Richtpreis zu erhalten. Anschließend erstellen wir Ihnen ein kostenloses, unverbindliches Angebot, damit Sie den genauen Preis im Voraus kennen.</p>
-</div>
-</div>
-</div>
-</div>
-</section>
-<section class="py-16 md:py-24 px-4 bg-card-light dark:bg-card-dark reveal" id="contact">
-<div class="container mx-auto max-w-2xl text-center">
-<h2 class="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4 md:mb-6">Fordern Sie ein Angebot an</h2>
-<p class="text-base md:text-lg text-text-light dark:text-text-dark mb-8 md:mb-10">Füllen Sie das untenstehende Formular aus und wir melden uns so schnell wie möglich mit einem kostenlosen, unverbindlichen Angebot bei Ihnen.</p>
-<form class="space-y-8 text-left" id="contact-form">
-  <!-- FIX: Inline status area provides graceful feedback and retry controls -->
-  <div aria-live="polite" class="hidden rounded-lg border p-4 text-sm transition-colors" data-contact-status role="status">
-    <p class="font-semibold" id="contact-status-message"></p>
-    <button class="mt-3 inline-flex items-center justify-center rounded-full border border-primary text-primary hover:bg-primary hover:text-white transition-colors px-4 py-2 text-sm font-semibold hidden" data-contact-retry type="button">
-      Erneut senden
-    </button>
-  </div>
-  <div class="grid gap-6 md:grid-cols-2">
-    <div>
-      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" for="first-name">Vorname<span class="text-red-500">*</span></label>
-      <input class="block w-full rounded-lg border-gray-300 dark:border-gray-600 bg-background-light dark:bg-background-dark shadow-sm focus:border-primary focus:ring-primary dark:text-white py-3 px-4 transition" id="first-name" name="first-name" autocomplete="given-name" required="" type="text"/>
-    </div>
-    <div>
-      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" for="last-name">Nachname<span class="text-red-500">*</span></label>
-      <input class="block w-full rounded-lg border-gray-300 dark:border-gray-600 bg-background-light dark:bg-background-dark shadow-sm focus:border-primary focus:ring-primary dark:text-white py-3 px-4 transition" id="last-name" name="last-name" autocomplete="family-name" required="" type="text"/>
-    </div>
-    <div>
-      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" for="email">E-Mail<span class="text-red-500">*</span></label>
-      <input class="block w-full rounded-lg border-gray-300 dark:border-gray-600 bg-background-light dark:bg-background-dark shadow-sm focus:border-primary focus:ring-primary dark:text-white py-3 px-4 transition" id="email" name="email" autocomplete="email" required="" type="email"/>
-    </div>
-    <div>
-      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" for="phone">Telefon<span class="text-red-500">*</span></label>
-      <input class="block w-full rounded-lg border-gray-300 dark:border-gray-600 bg-background-light dark:bg-background-dark shadow-sm focus:border-primary focus:ring-primary dark:text-white py-3 px-4 transition" id="phone" name="phone" autocomplete="tel" inputmode="tel" pattern="\+?[0-9 ()\-\/]{6,20}" placeholder="z. B. +49 171 1234567" required="" type="tel"/>
-    </div>
-  </div>
 
-  <div>
-    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" for="address">Adresse auswählen<span class="text-red-500">*</span></label>
-    <input class="block w-full rounded-lg border-gray-300 dark:border-gray-600 bg-background-light dark:bg-background-dark shadow-sm focus:border-primary focus:ring-primary dark:text-white py-3 px-4 transition" id="address" name="address" placeholder="Straße, Hausnummer, PLZ und Ort" required="" type="text"/>
-    <p class="mt-2 text-xs text-text-light dark:text-text-dark">Bitte nennen Sie die Adresse der Immobilie, damit wir den Einsatz planen können.</p>
-  </div>
-
-  <div class="grid gap-6 md:grid-cols-2">
-    <div>
-      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" for="gutter-height">Höhe der Dachrinne<span class="text-red-500">*</span></label>
-      <input class="block w-full rounded-lg border-gray-300 dark:border-gray-600 bg-background-light dark:bg-background-dark shadow-sm focus:border-primary focus:ring-primary dark:text-white py-3 px-4 transition" id="gutter-height" name="gutter-height" min="0" step="0.1" placeholder="geschätzte Höhe in Metern" required="" type="number"/>
-    </div>
-    <div>
-      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" for="gutter-length">Länge der Dachrinne<span class="text-red-500">*</span></label>
-      <input class="block w-full rounded-lg border-gray-300 dark:border-gray-600 bg-background-light dark:bg-background-dark shadow-sm focus:border-primary focus:ring-primary dark:text-white py-3 px-4 transition" id="gutter-length" name="gutter-length" min="0" step="0.5" placeholder="geschätzte Länge in Metern" required="" type="number"/>
-    </div>
-  </div>
-
-  <fieldset class="space-y-4">
-    <legend class="text-sm font-semibold text-gray-900 dark:text-white">Grund für die Dachrinnenreinigung</legend>
-    <div class="space-y-3">
-      <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
-        <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="reasons" type="checkbox" value="Ich habe verunreinigtes Wasser"/>
-        <span>Ich habe verunreinigtes Wasser</span>
-      </label>
-      <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
-        <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="reasons" type="checkbox" value="Wasserschäden an der Fassade"/>
-        <span>Wasserschäden an der Fassade</span>
-      </label>
-      <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
-        <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="reasons" type="checkbox" value="Pflanzen in der Rinne"/>
-        <span>Pflanzen in der Rinne</span>
-      </label>
-      <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
-        <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="reasons" type="checkbox" value="Dachrinne verstopft"/>
-        <span>Dachrinne verstopft</span>
-      </label>
-      <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
-        <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="reasons" type="checkbox" value="Ich bin mir unsicher"/>
-        <span>Ich bin mir unsicher</span>
-      </label>
-    </div>
-  </fieldset>
-
-  <fieldset class="space-y-4">
-    <legend class="text-sm font-semibold text-gray-900 dark:text-white">Dachrinnenschutz/Laubschutz</legend>
-    <div class="space-y-3">
-      <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
-        <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="guards" type="checkbox" value="Ich habe einen Dachrinnenschutz"/>
-        <span>Ich habe einen Dachrinnenschutz</span>
-      </label>
-      <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
-        <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="guards" type="checkbox" value="Ich benötige einen Dachrinnenschutz"/>
-        <span>Ich benötige einen Dachrinnenschutz</span>
-      </label>
-      <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
-        <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="guards" type="checkbox" value="Ich bin mir unsicher – möchte mich beraten lassen"/>
-        <span>Ich bin mir unsicher – möchte mich beraten lassen</span>
-      </label>
-      <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
-        <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="guards" type="checkbox" value="Ich habe einen Dachrinnenschutz, brauche eine Reparatur"/>
-        <span>Ich habe einen Dachrinnenschutz, brauche eine Reparatur</span>
-      </label>
-      <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
-        <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="guards" type="checkbox" value="Ich habe einen Dachrinnenschutz, brauche eine Reinigung"/>
-        <span>Ich habe einen Dachrinnenschutz, brauche eine Reinigung</span>
-      </label>
-    </div>
-  </fieldset>
-
-  <div class="flex items-start gap-3">
-    <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" id="consent" name="consent" required="" type="checkbox"/>
-    <label class="text-sm text-gray-700 dark:text-gray-300" for="consent">Ich habe die <a class="text-primary hover:text-primary-dark font-medium" href="https://www.dachrinnecheck.de/datenschutz" target="_blank" rel="noopener">Datenschutzerklärung</a> zur Kenntnis genommen.</label>
-  </div>
-
-  <div class="text-center pt-4">
-    <button class="bg-primary text-white font-bold py-3 px-8 md:py-4 md:px-10 rounded-full text-base md:text-lg hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105" type="submit">
-      Angebot anfordern
-    </button>
-  </div>
-</form>
-<div class="mt-10 text-center">
-    <a class="inline-flex items-center justify-center bg-primary text-white font-semibold py-3 px-8 md:py-4 md:px-10 rounded-full text-base md:text-lg hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105" href="https://www.dachrinnecheck.de/kostenrechner">
-      Zum Kostenrechner
-    </a>
-  </div>
-</div>
-</section>
-<footer class="bg-card-dark border-t border-gray-800 py-10 md:py-12">
-<div class="container mx-auto px-4 text-center text-text-dark">
-<div class="flex flex-col md:flex-row justify-center items-center space-y-4 md:space-y-0 md:space-x-8 mb-8">
-<a class="hover:text-primary transition-colors text-sm" href="https://www.dachrinnecheck.de/datenschutz">Datenschutz</a>
-<a class="hover:text-primary transition-colors text-sm" href="https://www.dachrinnecheck.de/impressum">Impressum</a>
-<a class="hover:text-primary transition-colors text-sm" href="https://www.dachrinnecheck.de/kostenrechner">Kostenrechner</a>
-<a class="hover:text-primary transition-colors text-sm" href="https://www.dachrinnecheck.de/#contact">Kontakt</a>
-</div>
-<p class="text-xs">© 2024 DachrinneCheck. Alle Rechte vorbehalten.</p>
-</div>
-</footer>
-</div>
 
 <script>
   const detectFunctionsBase = () => {
@@ -550,7 +147,7 @@ Original lesen
 
   const FUNCTIONS_BASE = detectFunctionsBase();
 
-  const createReviewEndpoints = limit => {
+  const createReviewEndpoints = (limit) => {
     const parsedLimit = Number.parseInt(limit, 10);
     const safeLimit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : 10;
     const alternateBase = FUNCTIONS_BASE === '/_functions' ? '/_functions-dev' : '/_functions';
@@ -611,7 +208,7 @@ Original lesen
             throw new Error('Keine Rezensionen in der Datenquelle gefunden.');
           }
 
-          const formatDate = value => {
+          const formatDate = (value) => {
             if (!value) {
               return '';
             }
@@ -622,7 +219,7 @@ Original lesen
             return date.toLocaleDateString('de-DE', { day: '2-digit', month: 'long', year: 'numeric' });
           };
 
-          const toBoolean = value => {
+          const toBoolean = (value) => {
             if (typeof value === 'string') {
               const normalized = value.trim().toLowerCase();
               return ['true', '1', 'yes', 'ja'].includes(normalized);
@@ -654,7 +251,7 @@ Original lesen
             };
           });
 
-          const withTexts = normalized.filter(review => review.text.length > 0);
+          const withTexts = normalized.filter((review) => review.text.length > 0);
 
           if (!withTexts.length) {
             throw new Error('Keine veröffentlichten Rezensionstexte vorhanden.');
@@ -670,7 +267,7 @@ Original lesen
         }
       },
       shuffleReviews() {
-        for (let index = this.reviews.length - 1; index > 0; index--) {
+        for (let index = this.reviews.length - 1; index > 0; index -= 1) {
           const swapIndex = Math.floor(Math.random() * (index + 1));
           [this.reviews[index], this.reviews[swapIndex]] = [this.reviews[swapIndex], this.reviews[index]];
         }
@@ -745,11 +342,50 @@ Original lesen
     };
   }
 
-  document.addEventListener('DOMContentLoaded', () => {
+  const loadPartials = async () => {
+    const placeholders = Array.from(document.querySelectorAll('[data-include]'));
+    if (!placeholders.length) {
+      return [];
+    }
+
+    const loadedSources = [];
+
+    await Promise.all(placeholders.map(async (placeholder) => {
+      const source = placeholder.getAttribute('data-include');
+      if (!source) {
+        return;
+      }
+
+      try {
+        const response = await fetch(source, { cache: 'no-store' });
+        if (!response.ok) {
+          throw new Error(`Status ${response.status}`);
+        }
+        const markup = await response.text();
+        placeholder.innerHTML = markup;
+        placeholder.removeAttribute('data-include');
+        loadedSources.push(source);
+      } catch (error) {
+        console.error(`Teil konnte nicht geladen werden: ${source}`, error);
+        placeholder.innerHTML = '<div class="px-4 py-6 text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg">Dieser Inhaltsbereich konnte nicht geladen werden.</div>';
+      }
+    }));
+
+    document.dispatchEvent(new CustomEvent('partials:loaded', { detail: { sources: loadedSources } }));
+    return loadedSources;
+  };
+
+  let contactFormInitialized = false;
+  const initContactForm = () => {
+    if (contactFormInitialized) {
+      return;
+    }
+
     const contactForm = document.querySelector('#contact-form');
     if (!contactForm) {
       return;
     }
+    contactFormInitialized = true;
 
     const firstNameInput = contactForm.querySelector('#first-name');
     const lastNameInput = contactForm.querySelector('#last-name');
@@ -806,7 +442,6 @@ Original lesen
       toggleRetry(false);
     };
 
-    // FIX: Present friendly feedback for validation, success and failure states
     const showStatus = (type, message, { showRetry = false } = {}) => {
       if (!statusContainer || !statusMessage) {
         return;
@@ -814,41 +449,35 @@ Original lesen
       removeStatusClasses();
       const classes = statusClassMap[type] || statusClassMap.info;
       classes.forEach((className) => statusContainer.classList.add(className));
-      statusContainer.classList.remove('hidden');
       statusContainer.dataset.state = type;
+      statusContainer.classList.remove('hidden');
       statusMessage.textContent = message;
       toggleRetry(showRetry);
     };
 
     const setSubmitDisabled = (disabled) => {
       submitButton.disabled = disabled;
+      submitButton.classList.toggle('opacity-75', disabled);
       submitButton.setAttribute('aria-disabled', disabled ? 'true' : 'false');
-      submitButton.classList.toggle('opacity-60', disabled);
-      submitButton.classList.toggle('cursor-not-allowed', disabled);
     };
 
     const updateSubmitState = () => {
-      if (isProcessing) {
+      if (!submitButton) {
         return;
       }
-      const shouldDisable = !contactForm.checkValidity();
-      setSubmitDisabled(shouldDisable);
-      if (!shouldDisable) {
-        submitButton.textContent = defaultButtonText;
+
+      if (isProcessing) {
+        setSubmitDisabled(true);
+        return;
       }
-    };
 
-    const startProcessing = () => {
-      isProcessing = true;
-      hideStatus();
-      setSubmitDisabled(true);
-      submitButton.textContent = 'Wird gesendet…';
-    };
+      const requiredInputs = [firstNameInput, lastNameInput, emailInput, phoneInput, addressInput, heightInput, lengthInput];
+      const hasEmptyRequired = requiredInputs.some((input) => !input.value.trim());
+      const hasConsent = consentInput.checked;
 
-    const stopProcessing = () => {
-      isProcessing = false;
-      submitButton.textContent = defaultButtonText;
-      updateSubmitState();
+      const hasErrors = requiredInputs.some((input) => input.validity.valid === false);
+      const disabled = hasEmptyRequired || !hasConsent || hasErrors;
+      setSubmitDisabled(disabled);
     };
 
     const resetCustomValidity = () => {
@@ -857,14 +486,47 @@ Original lesen
       });
     };
 
-    const watchInputs = [firstNameInput, lastNameInput, emailInput, phoneInput, addressInput, heightInput, lengthInput];
-    watchInputs.forEach((input) => {
+    const showErrorSummary = (errors) => {
+      if (!errors.length) {
+        hideStatus();
+        return;
+      }
+      showStatus('error', errors.join(' '));
+    };
+
+    const setProcessing = (processing) => {
+      isProcessing = processing;
+      if (processing) {
+        hideStatus();
+        setSubmitDisabled(true);
+        submitButton.textContent = 'Wird gesendet…';
+      } else {
+        submitButton.textContent = defaultButtonText;
+        updateSubmitState();
+      }
+    };
+
+    const parseNumberInput = (input) => {
+      if (!input) {
+        return null;
+      }
+      const rawValue = input.value.replace(',', '.').trim();
+      if (!rawValue) {
+        return null;
+      }
+      const numericValue = Number.parseFloat(rawValue);
+      return Number.isFinite(numericValue) ? numericValue : null;
+    };
+
+    const handleInputChange = (input) => {
       input.addEventListener('input', () => {
         input.setCustomValidity('');
         hideStatus();
         updateSubmitState();
       });
-    });
+    };
+
+    [firstNameInput, lastNameInput, emailInput, phoneInput, addressInput, heightInput, lengthInput].forEach(handleInputChange);
 
     [consentInput, ...reasonInputs, ...guardInputs].forEach((element) => {
       element.addEventListener('change', () => {
@@ -882,19 +544,7 @@ Original lesen
       });
     }
 
-    const parseNumberInput = input => {
-      if (!input) {
-        return null;
-      }
-      const rawValue = input.value.replace(',', '.').trim();
-      if (!rawValue) {
-        return null;
-      }
-      const numericValue = Number.parseFloat(rawValue);
-      return Number.isFinite(numericValue) ? numericValue : null;
-    };
-
-    contactForm.addEventListener('submit', async event => {
+    contactForm.addEventListener('submit', async (event) => {
       event.preventDefault();
 
       hideStatus();
@@ -956,13 +606,13 @@ Original lesen
 
       if (errors.length) {
         contactForm.reportValidity();
-        showStatus('error', errors.join(' '));
+        showErrorSummary(errors);
         updateSubmitState();
         return;
       }
 
-      const selectedReasons = reasonInputs.filter(input => input.checked).map(input => input.value);
-      const selectedGuards = guardInputs.filter(input => input.checked).map(input => input.value);
+      const selectedReasons = reasonInputs.filter((input) => input.checked).map((input) => input.value);
+      const selectedGuards = guardInputs.filter((input) => input.checked).map((input) => input.value);
       const messageParts = [];
       if (selectedReasons.length) {
         messageParts.push(`Grund für die Reinigung: ${selectedReasons.join(', ')}`);
@@ -972,7 +622,7 @@ Original lesen
       }
       const messageValue = messageParts.join(' | ');
 
-      startProcessing();
+      setProcessing(true);
 
       const contact = {
         vorname: firstName,
@@ -1016,7 +666,7 @@ Original lesen
         try {
           result = await response.json();
         } catch (jsonError) {
-          // ignore JSON parsing errors – will be handled by status check below
+          // Ignorieren – Fehler werden über Status behandelt
         }
 
         if (!response.ok || (result && result.ok === false)) {
@@ -1031,180 +681,198 @@ Original lesen
         console.error('Fehler beim Senden des Formulars:', error);
         showStatus('error', 'Ihre Anfrage konnte nicht gesendet werden. Bitte versuchen Sie es später erneut.', { showRetry: true });
       } finally {
-        stopProcessing();
+        setProcessing(false);
       }
     });
 
     updateSubmitState();
-  });
+  };
 
-    document.addEventListener('DOMContentLoaded', () => {
-      const reviewsSection = document.querySelector('#dynamic-reviews');
-      if (!reviewsSection) {
+  let dynamicReviewsInitialized = false;
+  const initDynamicReviews = () => {
+    if (dynamicReviewsInitialized) {
+      return;
+    }
+
+    const reviewsSection = document.querySelector('#dynamic-reviews');
+    if (!reviewsSection) {
+      return;
+    }
+    dynamicReviewsInitialized = true;
+
+    const listElement = reviewsSection.querySelector('#reviews-list');
+    const loadingElement = reviewsSection.querySelector('#reviews-loading');
+    const errorElement = reviewsSection.querySelector('#reviews-error');
+    const emptyElement = reviewsSection.querySelector('#reviews-empty');
+
+    if (!listElement) {
+      return;
+    }
+
+    const ENDPOINTS = createReviewEndpoints(10);
+
+    const showElement = (element, shouldShow) => {
+      if (!element) {
         return;
       }
+      if (shouldShow) {
+        element.classList.remove('hidden');
+      } else {
+        element.classList.add('hidden');
+      }
+    };
 
-      const listElement = reviewsSection.querySelector('#reviews-list');
-      const loadingElement = reviewsSection.querySelector('#reviews-loading');
-      const errorElement = reviewsSection.querySelector('#reviews-error');
-      const emptyElement = reviewsSection.querySelector('#reviews-empty');
+    const formatDate = (value) => {
+      if (!value) {
+        return '';
+      }
+      const date = value instanceof Date ? value : new Date(value);
+      if (Number.isNaN(date.getTime())) {
+        return '';
+      }
+      return date.toLocaleDateString('de-DE', { day: '2-digit', month: 'long', year: 'numeric' });
+    };
 
-      if (!listElement) {
-        return;
+    const clampRating = (value) => {
+      const numeric = Number.parseFloat(value);
+      if (!Number.isFinite(numeric)) {
+        return 0;
+      }
+      return Math.min(5, Math.max(0, numeric));
+    };
+
+    const createStarRow = (ratingValue) => {
+      const rating = clampRating(ratingValue);
+      const container = document.createElement('div');
+      container.className = 'flex items-center gap-1 text-yellow-400';
+      container.setAttribute('aria-label', `${Math.round(rating * 10) / 10} von 5 Sternen`);
+
+      for (let index = 1; index <= 5; index += 1) {
+        const span = document.createElement('span');
+        span.className = 'material-symbols-outlined text-xl';
+        if (rating >= index) {
+          span.textContent = 'star';
+        } else if (rating >= index - 0.5) {
+          span.textContent = 'star_half';
+        } else {
+          span.textContent = 'star_border';
+        }
+        container.appendChild(span);
       }
 
-      const ENDPOINTS = createReviewEndpoints(10);
+      const label = document.createElement('span');
+      label.className = 'ml-2 text-sm font-medium text-text-light dark:text-text-dark';
+      label.textContent = `${Math.round(rating * 10) / 10} / 5`;
+      container.appendChild(label);
 
-      const showElement = (element, shouldShow) => {
-        if (!element) {
+      return container;
+    };
+
+    const createReviewCard = (review) => {
+      const card = document.createElement('article');
+      card.className = 'bg-background-light dark:bg-background-dark border border-gray-200 dark:border-gray-700 rounded-xl p-6 shadow-sm flex flex-col gap-4';
+
+      const name = document.createElement('h4');
+      name.className = 'text-lg font-semibold text-gray-900 dark:text-white';
+      name.textContent = review?.name || 'Kunde';
+      card.appendChild(name);
+
+      card.appendChild(createStarRow(review?.rating));
+
+      if (review?.comment) {
+        const comment = document.createElement('p');
+        comment.className = 'text-sm md:text-base text-text-light dark:text-text-dark italic';
+        comment.textContent = review.comment;
+        card.appendChild(comment);
+      }
+
+      const meta = document.createElement('p');
+      meta.className = 'text-xs text-text-light dark:text-text-dark';
+      const formattedDate = formatDate(review?.date);
+      meta.textContent = formattedDate ? `Bewertet am ${formattedDate}` : 'Bewertung ohne Datumsangabe';
+      card.appendChild(meta);
+
+      return card;
+    };
+
+    const renderReviews = (reviews) => {
+      listElement.innerHTML = '';
+      reviews.forEach((review) => {
+        const card = createReviewCard(review);
+        listElement.appendChild(card);
+      });
+    };
+
+    const loadReviews = async () => {
+      showElement(loadingElement, true);
+      showElement(errorElement, false);
+      showElement(emptyElement, false);
+      showElement(listElement, false);
+
+      try {
+        let payload = null;
+        let lastError = null;
+
+        for (const endpoint of ENDPOINTS) {
+          try {
+            const response = await fetch(endpoint, { cache: 'no-store' });
+            if (!response.ok) {
+              throw new Error(`Serverantwort ${response.status}`);
+            }
+
+            payload = await response.json();
+
+            if (payload?.ok === false) {
+              const message = payload?.error || 'Die Kundenbewertungen konnten nicht geladen werden.';
+              throw new Error(message);
+            }
+
+            break;
+          } catch (requestError) {
+            lastError = requestError;
+          }
+        }
+
+        if (!payload) {
+          throw lastError || new Error('Die Kundenbewertungen konnten nicht geladen werden.');
+        }
+
+        const reviews = Array.isArray(payload?.items) ? payload.items : [];
+
+        if (!reviews.length) {
+          showElement(emptyElement, true);
           return;
         }
-        if (shouldShow) {
-          element.classList.remove('hidden');
-        } else {
-          element.classList.add('hidden');
+
+        renderReviews(reviews);
+        showElement(listElement, true);
+      } catch (error) {
+        console.error('Bewertungen konnten nicht geladen werden:', error);
+        if (errorElement) {
+          errorElement.textContent = 'Die Kundenbewertungen konnten nicht geladen werden. Bitte versuchen Sie es später erneut.';
         }
-      };
+        showElement(errorElement, true);
+      } finally {
+        showElement(loadingElement, false);
+      }
+    };
 
-      const formatDate = value => {
-        if (!value) {
-          return '';
-        }
-        const date = value instanceof Date ? value : new Date(value);
-        if (Number.isNaN(date.getTime())) {
-          return '';
-        }
-        return date.toLocaleDateString('de-DE', { day: '2-digit', month: 'long', year: 'numeric' });
-      };
+    loadReviews();
+  };
 
-      const clampRating = value => {
-        const numeric = Number.parseFloat(value);
-        if (!Number.isFinite(numeric)) {
-          return 0;
-        }
-        return Math.min(Math.max(numeric, 0), 5);
-      };
+  const bootstrapPage = async () => {
+    await loadPartials();
+    initContactForm();
+    initDynamicReviews();
+  };
 
-      const createStarRow = ratingValue => {
-        const rating = clampRating(ratingValue);
-        const container = document.createElement('div');
-        container.className = 'flex items-center gap-1 text-yellow-400';
-        container.setAttribute('aria-label', `${Math.round(rating * 10) / 10} von 5 Sternen`);
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bootstrapPage);
+  } else {
+    bootstrapPage();
+  }
+</script>
 
-        for (let index = 1; index <= 5; index += 1) {
-          const span = document.createElement('span');
-          span.className = 'material-symbols-outlined text-xl';
-          if (rating >= index) {
-            span.textContent = 'star';
-          } else if (rating >= index - 0.5) {
-            span.textContent = 'star_half';
-          } else {
-            span.textContent = 'star_border';
-          }
-          container.appendChild(span);
-        }
-
-        const label = document.createElement('span');
-        label.className = 'ml-2 text-sm font-medium text-text-light dark:text-text-dark';
-        label.textContent = `${Math.round(rating * 10) / 10} / 5`;
-        container.appendChild(label);
-
-        return container;
-      };
-
-      const createReviewCard = review => {
-        const card = document.createElement('article');
-        card.className = 'bg-background-light dark:bg-background-dark border border-gray-200 dark:border-gray-700 rounded-xl p-6 shadow-sm flex flex-col gap-4';
-
-        const name = document.createElement('h4');
-        name.className = 'text-lg font-semibold text-gray-900 dark:text-white';
-        name.textContent = review?.name || 'Kunde';
-        card.appendChild(name);
-
-        card.appendChild(createStarRow(review?.rating));
-
-        if (review?.comment) {
-          const comment = document.createElement('p');
-          comment.className = 'text-sm md:text-base text-text-light dark:text-text-dark italic';
-          comment.textContent = review.comment;
-          card.appendChild(comment);
-        }
-
-        const meta = document.createElement('p');
-        meta.className = 'text-xs text-text-light dark:text-text-dark';
-        const formattedDate = formatDate(review?.date);
-        meta.textContent = formattedDate ? `Bewertet am ${formattedDate}` : 'Bewertung ohne Datumsangabe';
-        card.appendChild(meta);
-
-        return card;
-      };
-
-      const renderReviews = reviews => {
-        listElement.innerHTML = '';
-
-        reviews.forEach(review => {
-          const card = createReviewCard(review);
-          listElement.appendChild(card);
-        });
-      };
-
-      const loadReviews = async () => {
-        showElement(loadingElement, true);
-        showElement(errorElement, false);
-        showElement(emptyElement, false);
-        showElement(listElement, false);
-
-        try {
-          let payload = null;
-          let lastError = null;
-
-          for (const endpoint of ENDPOINTS) {
-            try {
-              const response = await fetch(endpoint, { cache: 'no-store' });
-              if (!response.ok) {
-                throw new Error(`Serverantwort ${response.status}`);
-              }
-
-              payload = await response.json();
-
-              if (payload?.ok === false) {
-                const message = payload?.error || 'Die Kundenbewertungen konnten nicht geladen werden.';
-                throw new Error(message);
-              }
-
-              break;
-            } catch (requestError) {
-              lastError = requestError;
-            }
-          }
-
-          if (!payload) {
-            throw lastError || new Error('Die Kundenbewertungen konnten nicht geladen werden.');
-          }
-
-          const reviews = Array.isArray(payload?.items) ? payload.items : [];
-
-          if (!reviews.length) {
-            showElement(emptyElement, true);
-            return;
-          }
-
-          renderReviews(reviews);
-          showElement(listElement, true);
-        } catch (error) {
-          console.error('Bewertungen konnten nicht geladen werden:', error);
-          if (errorElement) {
-            errorElement.textContent = 'Die Kundenbewertungen konnten nicht geladen werden. Bitte versuchen Sie es später erneut.';
-          }
-          showElement(errorElement, true);
-        } finally {
-          showElement(loadingElement, false);
-        }
-      };
-
-      loadReviews();
-    });
-  </script>
 </div>
 <script defer="" src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </body></html>

--- a/docs/partials/about.html
+++ b/docs/partials/about.html
@@ -1,0 +1,10 @@
+<section class="py-16 md:py-20 px-4 bg-card-light dark:bg-card-dark reveal" id="about">
+  <div class="container mx-auto">
+    <div class="text-center max-w-3xl mx-auto">
+      <h2 class="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4 md:mb-6">Über DachrinneCheck</h2>
+      <p class="text-base md:text-lg text-text-light dark:text-text-dark leading-relaxed">
+        Willkommen bei DachrinneCheck, Ihrem zuverlässigen Partner für professionelle Dachrinnenreinigung in Nordrhein-Westfalen. Unsere Mission ist es, Ihr Zuhause vor Wasserschäden zu schützen, indem wir sicherstellen, dass Ihre Dachrinnen sauber, frei und voll funktionsfähig sind. Wir verpflichten uns zu qualitativ hochwertigem Service mit Fokus auf Zuverlässigkeit, Effizienz und Kundenzufriedenheit.
+      </p>
+    </div>
+  </div>
+</section>

--- a/docs/partials/contact.html
+++ b/docs/partials/contact.html
@@ -1,0 +1,118 @@
+<section class="py-16 md:py-24 px-4 bg-card-light dark:bg-card-dark reveal" id="contact">
+  <div class="container mx-auto max-w-2xl text-center">
+    <h2 class="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4 md:mb-6">Fordern Sie ein Angebot an</h2>
+    <p class="text-base md:text-lg text-text-light dark:text-text-dark mb-8 md:mb-10">Füllen Sie das untenstehende Formular aus und wir melden uns so schnell wie möglich mit einem kostenlosen, unverbindlichen Angebot bei Ihnen.</p>
+    <form class="space-y-8 text-left" id="contact-form">
+      <!-- FIX: Inline status area provides graceful feedback and retry controls -->
+      <div aria-live="polite" class="hidden rounded-lg border p-4 text-sm transition-colors" data-contact-status role="status">
+        <p class="font-semibold" id="contact-status-message"></p>
+        <button class="mt-3 inline-flex items-center justify-center rounded-full border border-primary text-primary hover:bg-primary hover:text-white transition-colors px-4 py-2 text-sm font-semibold hidden" data-contact-retry type="button">
+          Erneut senden
+        </button>
+      </div>
+      <div class="grid gap-6 md:grid-cols-2">
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" for="first-name">Vorname<span class="text-red-500">*</span></label>
+          <input class="block w-full rounded-lg border-gray-300 dark:border-gray-600 bg-background-light dark:bg-background-dark shadow-sm focus:border-primary focus:ring-primary dark:text-white py-3 px-4 transition" id="first-name" name="first-name" autocomplete="given-name" required type="text"/>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" for="last-name">Nachname<span class="text-red-500">*</span></label>
+          <input class="block w-full rounded-lg border-gray-300 dark:border-gray-600 bg-background-light dark:bg-background-dark shadow-sm focus:border-primary focus:ring-primary dark:text-white py-3 px-4 transition" id="last-name" name="last-name" autocomplete="family-name" required type="text"/>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" for="email">E-Mail<span class="text-red-500">*</span></label>
+          <input class="block w-full rounded-lg border-gray-300 dark:border-gray-600 bg-background-light dark:bg-background-dark shadow-sm focus:border-primary focus:ring-primary dark:text-white py-3 px-4 transition" id="email" name="email" autocomplete="email" required type="email"/>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" for="phone">Telefon<span class="text-red-500">*</span></label>
+          <input class="block w-full rounded-lg border-gray-300 dark:border-gray-600 bg-background-light dark:bg-background-dark shadow-sm focus:border-primary focus:ring-primary dark:text-white py-3 px-4 transition" id="phone" name="phone" autocomplete="tel" inputmode="tel" pattern="\+?[0-9 ()\-\/]{6,20}" placeholder="z. B. +49 171 1234567" required type="tel"/>
+        </div>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" for="address">Adresse auswählen<span class="text-red-500">*</span></label>
+        <input class="block w-full rounded-lg border-gray-300 dark:border-gray-600 bg-background-light dark:bg-background-dark shadow-sm focus:border-primary focus:ring-primary dark:text-white py-3 px-4 transition" id="address" name="address" placeholder="Straße, Hausnummer, PLZ und Ort" required type="text"/>
+        <p class="mt-2 text-xs text-text-light dark:text-text-dark">Bitte nennen Sie die Adresse der Immobilie, damit wir den Einsatz planen können.</p>
+      </div>
+
+      <div class="grid gap-6 md:grid-cols-2">
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" for="gutter-height">Höhe der Dachrinne<span class="text-red-500">*</span></label>
+          <input class="block w-full rounded-lg border-gray-300 dark:border-gray-600 bg-background-light dark:bg-background-dark shadow-sm focus:border-primary focus:ring-primary dark:text-white py-3 px-4 transition" id="gutter-height" name="gutter-height" min="0" step="0.1" placeholder="geschätzte Höhe in Metern" required type="number"/>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" for="gutter-length">Länge der Dachrinne<span class="text-red-500">*</span></label>
+          <input class="block w-full rounded-lg border-gray-300 dark:border-gray-600 bg-background-light dark:bg-background-dark shadow-sm focus:border-primary focus:ring-primary dark:text-white py-3 px-4 transition" id="gutter-length" name="gutter-length" min="0" step="0.5" placeholder="geschätzte Länge in Metern" required type="number"/>
+        </div>
+      </div>
+
+      <fieldset class="space-y-4">
+        <legend class="text-sm font-semibold text-gray-900 dark:text-white">Grund für die Dachrinnenreinigung</legend>
+        <div class="space-y-3">
+          <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
+            <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="reasons" type="checkbox" value="Ich habe verunreinigtes Wasser"/>
+            <span>Ich habe verunreinigtes Wasser</span>
+          </label>
+          <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
+            <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="reasons" type="checkbox" value="Wasserschäden an der Fassade"/>
+            <span>Wasserschäden an der Fassade</span>
+          </label>
+          <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
+            <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="reasons" type="checkbox" value="Pflanzen in der Rinne"/>
+            <span>Pflanzen in der Rinne</span>
+          </label>
+          <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
+            <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="reasons" type="checkbox" value="Dachrinne verstopft"/>
+            <span>Dachrinne verstopft</span>
+          </label>
+          <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
+            <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="reasons" type="checkbox" value="Ich bin mir unsicher"/>
+            <span>Ich bin mir unsicher</span>
+          </label>
+        </div>
+      </fieldset>
+
+      <fieldset class="space-y-4">
+        <legend class="text-sm font-semibold text-gray-900 dark:text-white">Dachrinnenschutz/Laubschutz</legend>
+        <div class="space-y-3">
+          <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
+            <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="guards" type="checkbox" value="Ich habe einen Dachrinnenschutz"/>
+            <span>Ich habe einen Dachrinnenschutz</span>
+          </label>
+          <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
+            <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="guards" type="checkbox" value="Ich benötige einen Dachrinnenschutz"/>
+            <span>Ich benötige einen Dachrinnenschutz</span>
+          </label>
+          <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
+            <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="guards" type="checkbox" value="Ich bin mir unsicher – möchte mich beraten lassen"/>
+            <span>Ich bin mir unsicher – möchte mich beraten lassen</span>
+          </label>
+          <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
+            <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="guards" type="checkbox" value="Ich habe einen Dachrinnenschutz, brauche eine Reparatur"/>
+            <span>Ich habe einen Dachrinnenschutz, brauche eine Reparatur</span>
+          </label>
+          <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
+            <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" name="guards" type="checkbox" value="Ich habe einen Dachrinnenschutz, brauche eine Reinigung"/>
+            <span>Ich habe einen Dachrinnenschutz, brauche eine Reinigung</span>
+          </label>
+        </div>
+      </fieldset>
+
+      <div class="flex items-start gap-3">
+        <input class="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" id="consent" name="consent" required type="checkbox"/>
+        <label class="text-sm text-gray-700 dark:text-gray-300" for="consent">Ich habe die <a class="text-primary hover:text-primary-dark font-medium" href="https://www.dachrinnecheck.de/datenschutz" target="_blank" rel="noopener">Datenschutzerklärung</a> zur Kenntnis genommen.</label>
+      </div>
+
+      <div class="text-center pt-4">
+        <button class="bg-primary text-white font-bold py-3 px-8 md:py-4 md:px-10 rounded-full text-base md:text-lg hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105" type="submit">
+          Angebot anfordern
+        </button>
+      </div>
+    </form>
+    <div class="mt-10 text-center">
+      <a class="inline-flex items-center justify-center bg-primary text-white font-semibold py-3 px-8 md:py-4 md:px-10 rounded-full text-base md:text-lg hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105" href="https://www.dachrinnecheck.de/kostenrechner">
+        Zum Kostenrechner
+      </a>
+    </div>
+  </div>
+</section>

--- a/docs/partials/faq.html
+++ b/docs/partials/faq.html
@@ -1,0 +1,40 @@
+<section class="py-16 md:py-20 px-4 bg-background-light dark:bg-background-dark reveal">
+  <div class="container mx-auto max-w-3xl">
+    <h2 class="text-3xl md:text-4xl font-bold text-center text-gray-900 dark:text-white mb-8 md:mb-12">Häufig gestellte Fragen</h2>
+    <div class="space-y-4 md:space-y-6" x-data="{ open: null }">
+      <div class="bg-card-light dark:bg-card-dark rounded-xl shadow-sm hover-lift reveal">
+        <button @click="open === 1 ? open = null : open = 1" class="w-full text-left p-4 md:p-6 flex justify-between items-center">
+          <span class="font-semibold text-base md:text-xl text-gray-900 dark:text-white">Wie oft sollte ich meine Dachrinnen reinigen lassen?</span>
+          <svg :class="{ 'rotate-180': open === 1 }" class="w-6 h-6 text-primary transform transition-transform duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M19 9l-7 7-7-7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+          </svg>
+        </button>
+        <div class="px-4 md:px-6 pb-4 md:pb-6 text-text-light dark:text-text-dark text-sm md:text-base" x-show="open === 1" x-transition:enter="transition ease-out duration-300" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" x-transition:leave="transition ease-in duration-200" x-transition:leave-start="opacity-100 translate-y-0" x-transition:leave-end="opacity-0 -translate-y-2">
+          <p>Wir empfehlen, Ihre Dachrinnen mindestens zweimal im Jahr reinigen zu lassen, typischerweise im Frühjahr und Herbst. Wenn Ihr Grundstück von vielen Bäumen umgeben ist, kann eine häufigere Reinigung erforderlich sein.</p>
+        </div>
+      </div>
+      <div class="bg-card-light dark:bg-card-dark rounded-xl shadow-sm hover-lift reveal">
+        <button @click="open === 2 ? open = null : open = 2" class="w-full text-left p-4 md:p-6 flex justify-between items-center">
+          <span class="font-semibold text-base md:text-xl text-gray-900 dark:text-white">Was ist Ihr Servicegebiet in NRW?</span>
+          <svg :class="{ 'rotate-180': open === 2 }" class="w-6 h-6 text-primary transform transition-transform duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M19 9l-7 7-7-7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+          </svg>
+        </button>
+        <div class="px-4 md:px-6 pb-4 md:pb-6 text-text-light dark:text-text-dark text-sm md:text-base" x-show="open === 2" x-transition:enter="transition ease-out duration-300" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" x-transition:leave="transition ease-in duration-200" x-transition:leave-start="opacity-100 translate-y-0" x-transition:leave-end="opacity-0 -translate-y-2">
+          <p>Wir bieten unsere Dachrinnenreinigungsdienste in der gesamten Region Nordrhein-Westfalen (NRW) an. Kontaktieren Sie uns mit Ihrer Adresse, um zu bestätigen, ob wir Ihren spezifischen Standort bedienen.</p>
+        </div>
+      </div>
+      <div class="bg-card-light dark:bg-card-dark rounded-xl shadow-sm hover-lift reveal">
+        <button @click="open === 3 ? open = null : open = 3" class="w-full text-left p-4 md:p-6 flex justify-between items-center">
+          <span class="font-semibold text-base md:text-xl text-gray-900 dark:text-white">Wie wird der Preis für die Dachrinnenreinigung bestimmt?</span>
+          <svg :class="{ 'rotate-180': open === 3 }" class="w-6 h-6 text-primary transform transition-transform duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M19 9l-7 7-7-7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+          </svg>
+        </button>
+        <div class="px-4 md:px-6 pb-4 md:pb-6 text-text-light dark:text-text-dark text-sm md:text-base" x-show="open === 3" x-transition:enter="transition ease-out duration-300" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" x-transition:leave="transition ease-in duration-200" x-transition:leave-start="opacity-100 translate-y-0" x-transition:leave-end="opacity-0 -translate-y-2">
+          <p>Die Kosten unseres Service hängen von mehreren Faktoren ab, darunter die Länge Ihrer Dachrinnen, die Höhe Ihres Gebäudes und die Menge an Schmutz. Nutzen Sie gern unseren <a class="text-primary hover:text-primary-dark font-semibold" href="https://www.dachrinnecheck.de/kostenrechner">Kostenrechner</a>, um in wenigen Sekunden einen transparenten Richtpreis zu erhalten. Anschließend erstellen wir Ihnen ein kostenloses, unverbindliches Angebot, damit Sie den genauen Preis im Voraus kennen.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/docs/partials/footer.html
+++ b/docs/partials/footer.html
@@ -1,0 +1,11 @@
+<footer class="bg-card-dark border-t border-gray-800 py-10 md:py-12">
+  <div class="container mx-auto px-4 text-center text-text-dark">
+    <div class="flex flex-col md:flex-row justify-center items-center space-y-4 md:space-y-0 md:space-x-8 mb-8">
+      <a class="hover:text-primary transition-colors text-sm" href="https://www.dachrinnecheck.de/datenschutz">Datenschutz</a>
+      <a class="hover:text-primary transition-colors text-sm" href="https://www.dachrinnecheck.de/impressum">Impressum</a>
+      <a class="hover:text-primary transition-colors text-sm" href="https://www.dachrinnecheck.de/kostenrechner">Kostenrechner</a>
+      <a class="hover:text-primary transition-colors text-sm" href="https://www.dachrinnecheck.de/#contact">Kontakt</a>
+    </div>
+    <p class="text-xs">© 2024 DachrinneCheck. Alle Rechte vorbehalten.</p>
+  </div>
+</footer>

--- a/docs/partials/gallery.html
+++ b/docs/partials/gallery.html
@@ -1,0 +1,30 @@
+<section class="py-16 md:py-20 px-4 bg-card-light dark:bg-card-dark reveal">
+  <div class="container mx-auto">
+    <div class="text-center max-w-3xl mx-auto mb-12 md:mb-16">
+      <h2 class="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4 md:mb-6">Sehen Sie den Unterschied</h2>
+      <p class="text-base md:text-lg text-text-light dark:text-text-dark">Unsere Vorher-Nachher-Galerie zeigt die Qualität und Effektivität unserer Dienstleistungen.</p>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-10">
+      <div class="rounded-xl overflow-hidden shadow-custom bg-card-light dark:bg-card-dark hover-lift reveal">
+        <div class="relative">
+          <img alt="Gutter before cleaning" class="w-full h-64 md:h-72 object-cover" src="https://static.wixstatic.com/media/6d33a0_e6c8065853f1475d97141c103c8f38a5~mv2.png"/>
+          <div class="absolute top-4 left-4 bg-red-500/80 text-white px-4 py-1 rounded-full text-xs md:text-sm font-semibold">Vorher</div>
+        </div>
+        <div class="p-6">
+          <h3 class="text-lg md:text-xl font-bold text-gray-900 dark:text-white mb-2">Verstopft und Überlaufend</h3>
+          <p class="text-text-light dark:text-text-dark text-sm md:text-base">Laub, Moos und Schmutz blockierten die Dachrinne vollständig, was zu einem Überlaufen des Wassers führte.</p>
+        </div>
+      </div>
+      <div class="rounded-xl overflow-hidden shadow-custom bg-card-light dark:bg-card-dark hover-lift reveal">
+        <div class="relative">
+          <img alt="Gutter after cleaning" class="w-full h-64 md:h-72 object-cover" src="https://static.wixstatic.com/media/6d33a0_b9208eaa790f49fcb1d72fa23dd847be~mv2.png"/>
+          <div class="absolute top-4 left-4 bg-green-500/80 text-white px-4 py-1 rounded-full text-xs md:text-sm font-semibold">Nachher</div>
+        </div>
+        <div class="p-6">
+          <h3 class="text-lg md:text-xl font-bold text-gray-900 dark:text-white mb-2">Sauber und Frei</h3>
+          <p class="text-text-light dark:text-text-dark text-sm md:text-base">Nach unserem Service ist die Dachrinne vollständig frei, sodass das Wasser frei fließen kann.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/docs/partials/header.html
+++ b/docs/partials/header.html
@@ -1,0 +1,48 @@
+<header class="sticky top-0 z-30 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg shadow-md transition-all duration-300 responsive-header" data-responsive-header>
+  <div class="container mx-auto flex justify-between items-center px-4 py-4 md:py-5" data-nav-inner>
+    <a class="inline-flex items-center" data-nav-logo href="https://www.dachrinnecheck.de/">
+      <img alt="DachrinneCheck Logo" src="https://static.wixstatic.com/media/6d33a0_2f72c9b480724f2b83a3784dddd3aa8f~mv2.png"/>
+      <span class="sr-only">Zur Startseite</span>
+    </a>
+    <nav aria-label="Hauptnavigation" class="hidden md:flex items-center gap-5 lg:gap-8 nav-inline" data-nav-inline>
+      <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="https://www.dachrinnecheck.de/#services">Services</a>
+      <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="https://www.dachrinnecheck.de/#about">Über uns</a>
+      <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors text-sm lg:text-base" href="https://www.dachrinnecheck.de/#contact">Kontakt</a>
+      <a class="bg-primary text-white font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base hover:bg-primary-dark transition-all duration-300 shadow transform hover:scale-105" href="https://www.dachrinnecheck.de/kostenrechner">
+        Zum Kostenrechner
+      </a>
+      <a class="bg-white text-primary font-semibold py-2.5 px-6 rounded-full text-sm lg:text-base border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow-sm" href="https://www.dachrinnecheck.de/#contact">
+        Angebot anfordern
+      </a>
+    </nav>
+    <div class="nav-toggle">
+      <button aria-controls="primary-navigation" aria-expanded="false" class="text-gray-900 dark:text-white" data-nav-label-close="Menü schließen" data-nav-label-open="Menü öffnen" data-nav-toggle type="button">
+        <span aria-hidden="true" class="material-symbols-outlined text-3xl">menu</span>
+        <span class="sr-only">Menü</span>
+      </button>
+    </div>
+  </div>
+  <div class="nav-dialog-backdrop" data-nav-overlay hidden>
+    <nav aria-hidden="true" aria-label="Mobile Navigation" aria-modal="true" class="nav-dialog" data-nav-dialog id="primary-navigation" role="dialog" tabindex="-1">
+      <button class="nav-dialog-close text-gray-900 dark:text-text-dark p-2" data-nav-close type="button">
+        <span aria-hidden="true" class="material-symbols-outlined text-2xl">close</span>
+        <span class="sr-only">Menü schließen</span>
+      </button>
+      <div class="flex flex-col items-center space-y-4 py-4 border-t border-gray-200 dark:border-gray-700 nav-dialog-content">
+        <div class="nav-dialog-links w-full flex flex-col items-center space-y-4">
+          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="https://www.dachrinnecheck.de/#services">Services</a>
+          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="https://www.dachrinnecheck.de/#about">Über uns</a>
+          <a class="text-gray-600 dark:text-text-dark hover:text-primary dark:hover:text-primary transition-colors py-2 w-full" data-nav-close href="https://www.dachrinnecheck.de/#contact">Kontakt</a>
+        </div>
+        <div class="nav-dialog-actions w-full flex flex-col items-center space-y-3">
+          <a class="bg-primary text-white font-semibold py-3 px-8 rounded-full text-base hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105 mt-2 w-full" data-nav-close href="https://www.dachrinnecheck.de/kostenrechner">
+            Zum Kostenrechner
+          </a>
+          <a class="bg-white text-primary font-semibold py-3 px-8 rounded-full text-base border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow mt-2 w-full" data-nav-close href="https://www.dachrinnecheck.de/#contact">
+            Angebot anfordern
+          </a>
+        </div>
+      </div>
+    </nav>
+  </div>
+</header>

--- a/docs/partials/hero.html
+++ b/docs/partials/hero.html
@@ -1,0 +1,18 @@
+<section class="relative text-white hero-section">
+  <div aria-hidden="true" class="hero-media">
+    <img alt="Arbeiter reinigt Dachrinne auf einem Gebäude" loading="lazy" src="https://static.wixstatic.com/media/6d33a0_0055e10499254c9ba395085f3325607f~mv2.png"/>
+  </div>
+  <div class="hero-overlay" aria-hidden="true"></div>
+  <div class="relative z-10 hero-content">
+    <h1 class="text-4xl md:text-6xl lg:text-7xl font-black leading-tight tracking-tight mb-4 md:mb-6 text-shadow">Professionelle Dachrinnenreinigung in NRW</h1>
+    <p class="text-lg md:text-2xl mb-8 md:mb-10 text-shadow font-light">Schützen Sie Ihr Eigentum vor Wasserschäden. Fordern Sie noch heute ein kostenloses Angebot an.</p>
+    <div class="flex flex-col sm:flex-row gap-4">
+      <a class="bg-primary text-white font-bold py-3 px-6 md:py-4 md:px-8 rounded-full text-base md:text-lg hover:bg-primary-dark transition-all duration-300 shadow-lg transform hover:scale-105 text-center" href="https://www.dachrinnecheck.de/kostenrechner">
+        Zum Kostenrechner
+      </a>
+      <a class="bg-white text-primary font-bold py-3 px-6 md:py-4 md:px-8 rounded-full text-base md:text-lg border border-primary hover:bg-primary-dark hover:text-white transition-all duration-300 shadow-lg transform hover:scale-105 text-center" href="https://www.dachrinnecheck.de/#contact">
+        Angebot anfordern
+      </a>
+    </div>
+  </div>
+</section>

--- a/docs/partials/services.html
+++ b/docs/partials/services.html
@@ -1,0 +1,37 @@
+<section class="py-16 md:py-20 px-4 bg-background-light dark:bg-background-dark reveal" id="services">
+  <div class="container mx-auto">
+    <div class="text-center max-w-3xl mx-auto mb-12 md:mb-16">
+      <h2 class="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4 md:mb-6">Umfassende Dachrinnenpflege</h2>
+      <p class="text-base md:text-lg text-text-light dark:text-text-dark">Wir bieten eine Reihe von Dienstleistungen an, um sicherzustellen, dass Ihre Dachrinnen in Top-Zustand sind.</p>
+    </div>
+    <div class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
+      <div class="bg-card-light dark:bg-card-dark p-8 rounded-xl text-center border border-gray-200 dark:border-gray-700 hover-lift reveal">
+        <div class="flex justify-center mb-5 text-primary">
+          <svg fill="currentColor" height="48" viewBox="0 0 256 256" width="48" xmlns="http://www.w3.org/2000/svg">
+            <path d="M218.83,103.77l-80-75.48a1.14,1.14,0,0,1-.11-.11,16,16,0,0,0-21.53,0l-.11.11L37.17,103.77A16,16,0,0,0,32,115.55V208a16,16,0,0,0,16,16H96a16,16,0,0,0,16-16V160h32v48a16,16,0,0,0,16,16h48a16,16,0,0,0,16-16V115.55A16,16,0,0,0,218.83,103.77ZM208,208H160V160a16,16,0,0,0-16-16H112a16,16,0,0,0-16,16v48H48V115.55l.11-.1L128,40l79.9,75.43.11.1Z"></path>
+          </svg>
+        </div>
+        <h3 class="text-xl md:text-2xl font-bold text-gray-900 dark:text-white mb-3">Dachrinnenreinigung</h3>
+        <p class="text-text-light dark:text-text-dark text-sm md:text-base">Gründliche Reinigung von Dachrinnen und Fallrohren, um Laub und Verstopfungen zu entfernen.</p>
+      </div>
+      <div class="bg-card-light dark:bg-card-dark p-8 rounded-xl text-center border border-gray-200 dark:border-gray-700 hover-lift reveal">
+        <div class="flex justify-center mb-5 text-primary">
+          <svg fill="currentColor" height="48" viewBox="0 0 256 256" width="48" xmlns="http://www.w3.org/2000/svg">
+            <path d="M223.45,40.07a8,8,0,0,0-7.52-7.52C139.8,28.08,78.82,51,52.82,94a87.09,87.09,0,0,0-12.76,49c.57,15.92,5.21,32,13.79,47.85l-19.51,19.5a8,8,0,0,0,11.32,11.32l19.5-19.51C81,210.73,97.09,215.37,113,215.94q1.67.06,3.33.06A86.93,86.93,0,0,0,162,203.18C205,177.18,227.93,116.21,223.45,40.07ZM153.75,189.5c-22.75,13.78-49.68,14-76.71.77l88.63-88.62a8,8,0,0,0-11.32-11.32L65.73,179c-13.19-27-13-54,.77-76.71,22.09-36.47,74.6-56.44,141.31-54.06C210.2,114.89,190.22,167.41,153.75,189.5Z"></path>
+          </svg>
+        </div>
+        <h3 class="text-xl md:text-2xl font-bold text-gray-900 dark:text-white mb-3">Schmutzentfernung</h3>
+        <p class="text-text-light dark:text-text-dark text-sm md:text-base">Entfernung aller Abfälle von Ihrem Grundstück, damit es sauber und ordentlich bleibt.</p>
+      </div>
+      <div class="bg-card-light dark:bg-card-dark p-8 rounded-xl text-center border border-gray-200 dark:border-gray-700 hover-lift reveal">
+        <div class="flex justify-center mb-5 text-primary">
+          <svg fill="currentColor" height="48" viewBox="0 0 256 256" width="48" xmlns="http://www.w3.org/2000/svg">
+            <path d="M208,40H48A16,16,0,0,0,32,56v58.78c0,89.61,75.82,119.34,91,124.39a15.53,15.53,0,0,0,10,0c15.2-5.05,91-34.78,91-124.39V56A16,16,0,0,0,208,40Zm0,74.79c0,78.42-66.35,104.62-80,109.18-13.53-4.51-80-30.69-80-109.18V56H208ZM82.34,141.66a8,8,0,0,1,11.32-11.32L112,148.68l50.34-50.34a8,8,0,0,1,11.32,11.32l-56,56a8,8,0,0,1-11.32,0Z"></path>
+          </svg>
+        </div>
+        <h3 class="text-xl md:text-2xl font-bold text-gray-900 dark:text-white mb-3">Dachrinneninspektion</h3>
+        <p class="text-text-light dark:text-text-dark text-sm md:text-base">Detaillierte Inspektion Ihrer Dachrinnen, um potenzielle Probleme oder Schäden zu identifizieren.</p>
+      </div>
+    </div>
+  </div>
+</section>

--- a/docs/partials/testimonials.html
+++ b/docs/partials/testimonials.html
@@ -1,0 +1,84 @@
+<section class="py-16 md:py-20 px-4 bg-card-light dark:bg-card-dark reveal">
+  <div class="container mx-auto">
+    <h2 class="text-3xl md:text-4xl font-bold text-center mb-4 md:mb-6 text-gray-900 dark:text-white">Was unsere Kunden sagen</h2>
+    <p class="text-base md:text-lg text-text-light dark:text-text-dark text-center mb-8 md:mb-12 max-w-2xl mx-auto">Hören Sie von unseren zufriedenen Kunden und erfahren Sie, warum sie DachrinneCheck vertrauen.</p>
+    <div class="relative max-w-3xl mx-auto" x-data="reviewsCarousel()" x-init="init()" x-cloak>
+      <div class="bg-white/70 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 text-center rounded-xl py-8" x-show="!ready && !error">
+        <p class="font-medium">Kundenstimmen werden geladen …</p>
+      </div>
+      <div class="bg-red-50 border border-red-200 text-red-700 dark:bg-red-900/30 dark:border-red-700 dark:text-red-200 rounded-xl p-6 text-center" x-show="error" x-transition>
+        <p class="font-semibold" x-text="error"></p>
+      </div>
+      <div @mouseenter="stopAutoRotate()" @mouseleave="startAutoRotate()" class="relative" x-show="ready" x-transition>
+        <div class="overflow-hidden">
+          <div :style="`transform: translateX(-${activeIndex * 100}%)`" class="flex transition-transform duration-500 ease-in-out">
+            <template x-for="(review, index) in reviews" :key="review.id || index">
+              <div class="flex-shrink-0 w-full p-2">
+                <div class="bg-background-light dark:bg-background-dark rounded-xl shadow-custom p-6 md:p-8 text-center hover-lift relative">
+                  <template x-if="review.highlighted">
+                    <span class="absolute top-4 right-4 bg-primary text-white text-xs font-semibold uppercase tracking-wide px-3 py-1 rounded-full">Top-Bewertung</span>
+                  </template>
+                  <div class="flex justify-center mb-4">
+                    <img :alt="`Avatar von ${review.name}`" :src="avatarUrl(review)" class="w-20 h-20 md:w-24 md:h-24 rounded-full object-cover border-4 border-white shadow"/>
+                  </div>
+                  <div class="flex flex-wrap justify-center items-center gap-2 mb-3" x-show="review.verified || review.source">
+                    <template x-if="review.verified">
+                      <span class="flex items-center text-xs font-semibold text-green-700 bg-green-100 dark:text-green-200 dark:bg-green-900/60 px-3 py-1 rounded-full">
+                        <span class="material-symbols-outlined text-base mr-1">verified</span>
+                        Verifiziert
+                      </span>
+                    </template>
+                    <template x-if="review.source">
+                      <span class="text-xs text-text-light dark:text-text-dark px-3 py-1 rounded-full border border-gray-200 dark:border-gray-700 bg-white/80 dark:bg-gray-800/70" x-text="review.source"></span>
+                    </template>
+                  </div>
+                  <div class="flex justify-center text-yellow-400 mb-4">
+                    <template x-for="star in 5" :key="`${review.id || index}-star-${star}`">
+                      <span class="material-symbols-outlined" x-text="starIcon(star, review.rating)"></span>
+                    </template>
+                  </div>
+                  <p class="text-base md:text-lg text-text-light dark:text-text-dark italic mb-4">&bdquo;<span x-text="review.text"></span>&ldquo;</p>
+                  <p class="font-bold text-gray-900 dark:text-white" x-text="review.name"></p>
+                  <p class="text-sm text-text-light dark:text-text-dark mb-3" x-text="formatMeta(review)"></p>
+                  <template x-if="review.link">
+                    <p class="text-sm">
+                      <a :href="review.link" class="text-primary hover:text-primary-dark font-medium inline-flex items-center gap-1" rel="noopener" target="_blank">
+                        Original lesen
+                        <span class="material-symbols-outlined text-base">open_in_new</span>
+                      </a>
+                    </p>
+                  </template>
+                </div>
+              </div>
+            </template>
+          </div>
+        </div>
+        <button :aria-disabled="reviews.length <= 1" :class="{'opacity-40 cursor-not-allowed': reviews.length <= 1}" @click="previous" class="absolute top-1/2 -translate-y-1/2 left-0 -translate-x-4 md:-translate-x-1/2 bg-white dark:bg-gray-800 rounded-full p-2 shadow-md hover:bg-gray-100 dark:hover:bg-gray-700 transition transform hover:scale-110" type="button">
+          <span class="material-symbols-outlined text-primary">chevron_left</span>
+        </button>
+        <button :aria-disabled="reviews.length <= 1" :class="{'opacity-40 cursor-not-allowed': reviews.length <= 1}" @click="next" class="absolute top-1/2 -translate-y-1/2 right-0 translate-x-4 md:translate-x-1/2 bg-white dark:bg-gray-800 rounded-full p-2 shadow-md hover:bg-gray-100 dark:hover:bg-gray-700 transition transform hover:scale-110" type="button">
+          <span class="material-symbols-outlined text-primary">chevron_right</span>
+        </button>
+      </div>
+      <div class="flex justify-center space-x-2 mt-6 md:mt-8" x-show="ready && reviews.length > 1">
+        <template x-for="(review, index) in reviews" :key="`${review.id || index}-indicator`">
+          <button :aria-label="`Bewertung ${index + 1} anzeigen`" :class="{'bg-primary scale-110': activeIndex === index, 'bg-gray-300 dark:bg-gray-600': activeIndex !== index}" @click="goTo(index)" class="w-3 h-3 rounded-full transition transform" type="button"></button>
+        </template>
+      </div>
+    </div>
+    <div class="mt-12" id="dynamic-reviews">
+      <div class="text-center max-w-3xl mx-auto mb-8">
+        <h3 class="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white">Aktuelle Kundenbewertungen</h3>
+        <p class="text-base md:text-lg text-text-light dark:text-text-dark">Echte Rückmeldungen aus unserer Reviews-CMS-Sammlung – automatisch aktualisiert.</p>
+      </div>
+      <div class="max-w-4xl mx-auto space-y-6">
+        <div class="bg-white/70 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 rounded-xl p-6 text-center" id="reviews-loading">
+          <p class="font-medium">Bewertungen werden geladen …</p>
+        </div>
+        <div class="hidden bg-red-50 border border-red-200 text-red-700 dark:bg-red-900/30 dark:border-red-700 dark:text-red-200 rounded-xl p-6 text-center" id="reviews-error"></div>
+        <div class="hidden text-text-light dark:text-text-dark text-center" id="reviews-empty">Noch keine veröffentlichten Bewertungen vorhanden.</div>
+        <div class="grid gap-6 md:grid-cols-2" id="reviews-list"></div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/docs/partials/video-showcase.html
+++ b/docs/partials/video-showcase.html
@@ -1,0 +1,18 @@
+<section class="py-16 md:py-20 px-4 bg-background-light dark:bg-background-dark reveal">
+  <div class="container mx-auto">
+    <div class="text-center max-w-3xl mx-auto mb-12 md:mb-16">
+      <h2 class="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4 md:mb-6">Sehen Sie unsere Arbeit in Aktion</h2>
+      <p class="text-base md:text-lg text-text-light dark:text-text-dark">Schauen Sie sich unser Video an, um einen Einblick in unseren professionellen Reinigungsprozess und die Ergebnisse zu erhalten, die wir liefern.</p>
+    </div>
+    <div class="max-w-4xl mx-auto">
+      <div class="rounded-xl overflow-hidden shadow-custom hover-lift">
+        <div class="relative w-full" style="padding-top: 56.25%;">
+          <video class="absolute inset-0 w-full h-full object-cover" controls preload="metadata" playsinline>
+            <source src="https://video.wixstatic.com/video/6d33a0_8388ea3febb544bba1a01ab1de3c0b1a/720p/mp4/file.mp4" type="video/mp4"/>
+            Ihr Browser unterstützt das Abspielen dieses Videos nicht.
+          </video>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- split the landing page into reusable HTML partials and reference them from the main document
- add an asynchronous loader that fetches partials before initializing the contact form and dynamic reviews logic
- update the responsive navigation script so it can initialize once partial content has been injected

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68ce67bc4580832983365eead928f3cf