### PR TITLE
Adjust hero hero section spacing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -75,7 +75,7 @@
       z-index: -1;
     }
     .hero-content {
-      padding: clamp(3rem, 6vw, 6rem) clamp(1.5rem, 5vw, 4rem);
+      padding: clamp(4rem, 10vw, 7rem) clamp(1.5rem, 5vw, 4rem) clamp(3rem, 8vw, 6.5rem);
       width: min(100%, 720px);
     }
     [x-cloak] {


### PR DESCRIPTION
## Summary
- increase the hero copy padding to add more top offset and breathing room under the sticky header

## Testing
- manual verification in browser

------
https://chatgpt.com/codex/tasks/task_b_68ce9a39144c832988f28b6a413bb274