### PR TITLE
Improve hero responsiveness on narrow viewports

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -92,6 +92,12 @@
         max(clamp(1.75rem, 7vw, 3rem), calc(1.75rem + var(--hero-safe-bottom)));
       width: min(100%, 720px);
     }
+    @media (max-width: 639px) {
+      .hero-content {
+        padding: clamp(3rem, 12vw, 4.5rem) clamp(1.75rem, 6vw, 3.5rem)
+          max(clamp(2.25rem, 11vw, 3.75rem), calc(2.25rem + var(--hero-safe-bottom)));
+      }
+    }
     @media (min-width: 768px) {
       .hero-content {
         padding: clamp(4rem, 10vw, 7rem) clamp(1.5rem, 5vw, 4rem) clamp(3rem, 8vw, 6.5rem);
@@ -101,6 +107,11 @@
       font-size: clamp(2.35rem, 8vw, 3.35rem);
       line-height: 1.1;
       letter-spacing: -0.015em;
+      hyphens: auto;
+    }
+    .hero-title,
+    .hero-subtitle {
+      text-wrap: balance;
     }
     @media (min-width: 640px) {
       .hero-title {
@@ -113,6 +124,14 @@
     @media (min-width: 640px) {
       .hero-subtitle {
         font-size: clamp(1.125rem, 3.2vw, 1.75rem);
+      }
+    }
+    @media (max-width: 479px) {
+      .hero-title {
+        font-size: clamp(1.75rem, 8.25vw, 2.85rem);
+      }
+      .hero-subtitle {
+        font-size: clamp(0.95rem, 4.75vw, 1.3rem);
       }
     }
     .hero-cta {


### PR DESCRIPTION
## Summary
- increase hero padding on small screens to keep text comfortably inside the safe area
- tweak hero typography and add balanced wrapping so headings scale down on narrow viewports

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_b_68ceae65b700832995db9125cf493c1b